### PR TITLE
ci: enhance tests workflow with coverage reporting and badge

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
     report:
         name: PR Report
         needs: [tests]
-        if: always() && github.event_name == 'pull_request'
+        if: "!cancelled() && github.event_name == 'pull_request'"
         runs-on: ubuntu-latest
         permissions:
             contents: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,13 +85,22 @@ jobs:
                   workflow_conclusion: success
                   if_no_artifact_found: warn
 
+            - name: Check baseline exists
+              id: baseline-exists
+              run: |
+                  if [ -f coverage-baseline/coverage-summary.json ]; then
+                    echo "exists=true" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "exists=false" >> "$GITHUB_OUTPUT"
+                  fi
+
             - name: Coverage report with delta
               uses: davelosert/vitest-coverage-report-action@v2
               with:
                   name: Tests
                   json-summary-path: coverage/coverage-summary.json
                   json-final-path: coverage/coverage-final.json
-                  json-summary-compare-path: ${{ steps.download-baseline.outcome == 'success' && 'coverage-baseline/coverage-summary.json' || '' }}
+                  json-summary-compare-path: ${{ steps.baseline-exists.outputs.exists == 'true' && 'coverage-baseline/coverage-summary.json' || '' }}
                   file-coverage-mode: all
 
     # ── Master push: update coverage badge ───────────────────────────────

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Testing
+name: Tests
 
 on:
     push:
@@ -7,22 +7,29 @@ on:
         branches: [master]
 
 jobs:
-    test:
-        runs-on: ubuntu-22.04
-        strategy:
-            matrix:
-                node-version: [20]
+    # ── Run tests with coverage ──────────────────────────────────────────
+
+    tests:
+        name: Tests
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+
         steps:
-            - uses: actions/checkout@v4
+            - name: Checkout code
+              uses: actions/checkout@v4
+
             - name: Install pnpm
               uses: pnpm/action-setup@v4
               with:
                   version: 10
-            - name: Use Node.js ${{ matrix.node-version }}
+
+            - name: Setup Node.js
               uses: actions/setup-node@v4
               with:
-                  node-version: ${{ matrix.node-version }}
+                  node-version: '20'
                   cache: 'pnpm'
+
             - name: Install dependencies
               run: pnpm install --frozen-lockfile
 
@@ -31,7 +38,91 @@ jobs:
               env:
                   DATABASE_URL: 'file:./prisma/test.db'
 
-            - name: Run tests
-              run: pnpm test:run
+            - name: Run tests with coverage
+              run: pnpm test:coverage
               env:
                   DATABASE_URL: 'file:./prisma/test.db'
+
+            - name: Upload coverage
+              uses: actions/upload-artifact@v4
+              if: always()
+              with:
+                  name: coverage
+                  path: coverage/
+                  retention-days: 7
+
+    # ── PR report ────────────────────────────────────────────────────────
+
+    report:
+        name: PR Report
+        needs: [tests]
+        if: always() && github.event_name == 'pull_request'
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            pull-requests: write
+            actions: read
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Download PR coverage
+              uses: actions/download-artifact@v4
+              with:
+                  name: coverage
+                  path: coverage/
+
+            - name: Download master baseline coverage
+              uses: dawidd6/action-download-artifact@v17
+              continue-on-error: true
+              id: download-baseline
+              with:
+                  workflow: tests.yml
+                  branch: master
+                  name: coverage
+                  path: coverage-baseline/
+                  workflow_conclusion: success
+                  if_no_artifact_found: warn
+
+            - name: Coverage report with delta
+              uses: davelosert/vitest-coverage-report-action@v2
+              with:
+                  name: Tests
+                  json-summary-path: coverage/coverage-summary.json
+                  json-final-path: coverage/coverage-final.json
+                  json-summary-compare-path: ${{ steps.download-baseline.outcome == 'success' && 'coverage-baseline/coverage-summary.json' || '' }}
+                  file-coverage-mode: all
+
+    # ── Master push: update coverage badge ───────────────────────────────
+
+    update-badge:
+        name: Update Coverage Badge
+        needs: [tests]
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Download coverage
+              uses: actions/download-artifact@v4
+              with:
+                  name: coverage
+                  path: coverage/
+
+            - name: Generate badge JSON file
+              run: |
+                  PCT=$(node -e "const s = require('./coverage/coverage-summary.json'); console.log(s.total.lines.pct)")
+                  if (( $(echo "$PCT >= 90" | bc -l) )); then COLOR=brightgreen
+                  elif (( $(echo "$PCT >= 80" | bc -l) )); then COLOR=green
+                  elif (( $(echo "$PCT >= 70" | bc -l) )); then COLOR=yellowgreen
+                  elif (( $(echo "$PCT >= 60" | bc -l) )); then COLOR=yellow
+                  else COLOR=red; fi
+                  echo "{\"schemaVersion\":1,\"label\":\"coverage\",\"message\":\"${PCT}%\",\"color\":\"${COLOR}\"}" > badge.json
+
+            - name: Update Gist badge
+              uses: exuanbo/actions-deploy-gist@v1
+              with:
+                  token: ${{ secrets.GIST_TOKEN }}
+                  gist_id: ${{ secrets.COVERAGE_GIST_ID }}
+                  gist_file_name: syntharena-coverage.json
+                  file_path: badge.json

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![isChemist Protocol v1.0.0](https://img.shields.io/badge/protocol-isChemist%20v1.0.0-blueviolet)](https://github.com/ischemist/protocol)
 [![arXiv](https://img.shields.io/badge/arXiv-2512.07079-b31b1b.svg)](https://arxiv.org/abs/2512.07079)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/anmorgunov/6077067d66b794810c2c667b79677304/raw/syntharena-coverage.json)](https://github.com/ischemist/syntharena/actions/workflows/tests.yml)
 
 Powered by [RetroCast](https://github.com/ischemist/project-procrustes)
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
         fileParallelism: false,
         coverage: {
             provider: 'v8',
-            reporter: ['text', 'json', 'html'],
+            reporter: ['text', 'json', 'json-summary', 'html'],
             include: [
                 'src/lib/route-visualization/**/*.ts',
                 'src/lib/services/**/*.ts',


### PR DESCRIPTION
## Summary

- Upgraded `.github/workflows/tests.yml` from a single bare job to three jobs:
  - **tests**: runs `pnpm test:coverage` and uploads the `coverage/` artifact
  - **report** (PR-only): posts a coverage-delta comment comparing PR coverage against the master baseline using `davelosert/vitest-coverage-report-action`
  - **update-badge** (master-push-only): generates a Shields.io badge JSON from coverage and deploys it to a GitHub Gist
- Added `json-summary` to vitest coverage reporters (required by both the PR report action and badge generation)
- Added coverage badge to README

Requires `GIST_TOKEN` and `COVERAGE_GIST_ID` repo secrets (already configured).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR upgrades the CI test workflow from a single job running `pnpm test:run` into three well-structured jobs: **tests** (runs coverage and uploads artifact), **report** (PR-only coverage delta comment via `davelosert/vitest-coverage-report-action`), and **update-badge** (master-push-only Shields.io badge via GitHub Gist). The `vitest.config.ts` gains `json-summary` as a coverage reporter to support both downstream consumers, and the README gets a coverage badge.

- Clean separation of concerns across the three workflow jobs with appropriate `if` conditions and permissions
- `json-summary` reporter addition in vitest config correctly supports both the PR report action and badge generation
- Minor improvement opportunity: use `!cancelled()` instead of `always()` on the `report` job to avoid unnecessary runner spin-up on cancelled workflows

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it's a CI-only change with no impact on application code.
- Score reflects well-structured CI changes following established patterns. The only concern is a minor best-practice improvement on the `report` job condition (`!cancelled()` vs `always()`), which doesn't affect correctness.
- `.github/workflows/tests.yml` — minor improvement on the `report` job `if` condition

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/tests.yml | Refactored from single job to three jobs (tests, report, update-badge) adding coverage artifact upload, PR delta comments, and Shields.io badge generation. Well-structured with appropriate permissions and conditional triggers. |
| vitest.config.ts | Added `json-summary` to coverage reporters, required by both the PR coverage report action and badge generation script. |
| README.md | Added a coverage badge pointing to the Gist-hosted Shields.io endpoint, linking to the workflow run page. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Push to master / PR opened] --> B[tests job]
    B -->|Run pnpm test:coverage| C[Upload coverage artifact]
    C --> D{Event type?}
    D -->|pull_request| E[report job]
    D -->|push to master| F[update-badge job]
    E --> G[Download PR coverage artifact]
    G --> H[Download master baseline artifact]
    H --> I[Post coverage delta comment on PR]
    F --> J[Download coverage artifact]
    J --> K[Generate badge JSON from coverage %]
    K --> L[Deploy badge to GitHub Gist]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/tests.yml
Line: 59

Comment:
**Report runs on cancelled workflows**

The `always()` condition means this job runs even if the `tests` job was **cancelled** (not just failed). If someone cancels a long-running workflow, the `report` job will still spin up a runner and attempt to post a coverage comment — likely failing at the artifact download step since coverage wasn't generated. Consider using `!cancelled()` instead of `always()` to skip report generation on cancellation while still reporting when tests fail:

```suggestion
        if: "!cancelled() && github.event_name == 'pull_request'"
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 92617db</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->