### PR TITLE
feat: introduce ReactionStep table for reaction-level deduplication

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
         "@fast-check/vitest": "^0.3.0",
         "@ianvs/prettier-plugin-sort-imports": "^4.7.0",
         "@tailwindcss/postcss": "^4",
+        "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "devDependencies": {
         "@fast-check/vitest": "^0.3.0",
         "@ianvs/prettier-plugin-sort-imports": "^4.7.0",
+        "@paralleldrive/cuid2": "^3.3.0",
         "@tailwindcss/postcss": "^4",
         "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
       '@ianvs/prettier-plugin-sort-imports':
         specifier: ^4.7.0
         version: 4.7.0(prettier@3.6.2)
+      '@paralleldrive/cuid2':
+        specifier: ^3.3.0
+        version: 3.3.0
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.1.17
@@ -684,6 +687,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@noble/hashes@2.0.1':
+    resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
+    engines: {node: '>= 20.19.0'}
+
   '@oxfmt/darwin-arm64@0.20.0':
     resolution: {integrity: sha512-bjR5dqvrd9gxKYfYR0ljUu3/T3+TuDVWcwA7d+tsfmx9lqidlw3zhgBTblnjF1mrd1zkPMoc5zzq86GeSEt1cA==}
     cpu: [arm64]
@@ -793,6 +800,10 @@ packages:
     resolution: {integrity: sha512-yPFcj6umrhusnG/kMS5wh96vblsqZ0kArQJS+7kEOSJDrH+DsFWaDCsSRF8U6gmSmZJ26KVMU3C3TMpqDN4M1g==}
     cpu: [x64]
     os: [win32]
+
+  '@paralleldrive/cuid2@3.3.0':
+    resolution: {integrity: sha512-OqiFvSOF0dBSesELYY2CAMa4YINvlLpvKOz/rv6NeZEqiyttlHgv98Juwv4Ch+GrEV7IZ8jfI2VcEoYUjXXCjw==}
+    hasBin: true
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -1804,6 +1815,9 @@ packages:
   better-sqlite3@11.10.0:
     resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
 
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
@@ -2037,6 +2051,9 @@ packages:
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
+
+  error-causes@3.0.2:
+    resolution: {integrity: sha512-i0B8zq1dHL6mM85FGoxaJnVtx6LD5nL2v0hlpGdntg5FOSyzQ46c9lmz5qx0xRS2+PWHGOHcYxGIBC5Le2dRMw==}
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
@@ -3403,6 +3420,8 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.1.5':
     optional: true
 
+  '@noble/hashes@2.0.1': {}
+
   '@oxfmt/darwin-arm64@0.20.0':
     optional: true
 
@@ -3468,6 +3487,12 @@ snapshots:
 
   '@oxlint/win32-x64@1.35.0':
     optional: true
+
+  '@paralleldrive/cuid2@3.3.0':
+    dependencies:
+      '@noble/hashes': 2.0.1
+      bignumber.js: 9.3.1
+      error-causes: 3.0.2
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -4468,6 +4493,8 @@ snapshots:
       bindings: 1.5.0
       prebuild-install: 7.1.3
 
+  bignumber.js@9.3.1: {}
+
   bindings@1.5.0:
     dependencies:
       file-uri-to-path: 1.0.0
@@ -4692,6 +4719,8 @@ snapshots:
       tapable: 2.3.0
 
   environment@1.1.0: {}
+
+  error-causes@3.0.2: {}
 
   es-module-lexer@1.7.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.1.17
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
       '@types/node':
         specifier: ^20
         version: 20.19.25
@@ -1607,6 +1610,9 @@ packages:
   '@tanstack/table-core@8.21.3':
     resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
     engines: {node: '>=12'}
+
+  '@types/better-sqlite3@7.6.13':
+    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -4241,6 +4247,10 @@ snapshots:
       react-dom: 19.2.0(react@19.2.0)
 
   '@tanstack/table-core@8.21.3': {}
+
+  '@types/better-sqlite3@7.6.13':
+    dependencies:
+      '@types/node': 20.19.25
 
   '@types/chai@5.2.3':
     dependencies:

--- a/prisma/migrations/20260315000000_add_reaction_step_table/migration.sql
+++ b/prisma/migrations/20260315000000_add_reaction_step_table/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable: ReactionStep (shared, deduplicated reaction data)
+CREATE TABLE "ReactionStep" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "reactionHash" TEXT NOT NULL,
+    "template" TEXT,
+    "metadata" TEXT
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ReactionStep_reactionHash_key" ON "ReactionStep"("reactionHash");
+
+-- AddColumn: reactionStepId to RouteNode (nullable, no FK constraint yet — added after data migration)
+ALTER TABLE "RouteNode" ADD COLUMN "reactionStepId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "RouteNode_reactionStepId_idx" ON "RouteNode"("reactionStepId");

--- a/prisma/migrations/20260315000001_drop_deprecated_routenode_columns/migration.sql
+++ b/prisma/migrations/20260315000001_drop_deprecated_routenode_columns/migration.sql
@@ -1,0 +1,7 @@
+-- Drop deprecated columns from RouteNode (now stored in ReactionStep)
+-- Requires SQLite >= 3.35.0 for ALTER TABLE DROP COLUMN support.
+
+-- Drop the old inline reaction data columns
+ALTER TABLE "RouteNode" DROP COLUMN "reactionHash";
+ALTER TABLE "RouteNode" DROP COLUMN "template";
+ALTER TABLE "RouteNode" DROP COLUMN "metadata";

--- a/prisma/migrations/20260315000001_drop_deprecated_routenode_columns/migration.sql
+++ b/prisma/migrations/20260315000001_drop_deprecated_routenode_columns/migration.sql
@@ -1,6 +1,30 @@
 -- Drop deprecated columns from RouteNode (now stored in ReactionStep)
 -- Requires SQLite >= 3.35.0 for ALTER TABLE DROP COLUMN support.
 
+-- Refuse to drop legacy columns until every RouteNode carrying inline reaction
+-- data has been backfilled to ReactionStep.
+CREATE TEMP TABLE "__reactionstep_backfill_guard" (
+    "ok" INTEGER NOT NULL,
+    CONSTRAINT "reactionstep_backfill_required" CHECK ("ok" = 1)
+);
+
+INSERT INTO "__reactionstep_backfill_guard" ("ok")
+SELECT CASE
+    WHEN EXISTS (
+        SELECT 1
+        FROM "RouteNode"
+        WHERE "reactionStepId" IS NULL
+          AND (
+              "reactionHash" IS NOT NULL
+              OR "template" IS NOT NULL
+              OR "metadata" IS NOT NULL
+          )
+    ) THEN 0
+    ELSE 1
+END;
+
+DROP TABLE "__reactionstep_backfill_guard";
+
 -- Drop the old inline reaction data columns
 ALTER TABLE "RouteNode" DROP COLUMN "reactionHash";
 ALTER TABLE "RouteNode" DROP COLUMN "template";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -237,26 +237,37 @@ model PredictionRoute {
   @@index([routeId])
 }
 
-model RouteNode {
-  id         String  @id @default(cuid())
-  routeId    String
-  moleculeId String
-  parentId   String? // Tree structure
+// Shared, deduplicated reaction step data.
+// Mirrors retrocast.models.chem.ReactionStep from the Python library.
+// Multiple RouteNodes across different routes can reference the same ReactionStep
+// when they represent the identical reaction (same product + reactants by InChIKey).
+model ReactionStep {
+  id           String @id @default(cuid())
+  reactionHash String @unique // SHA256 of "productInchikey>>reactant1Inchikey.reactant2Inchikey" (sorted)
+  template     String? // Reaction template (e.g., SMARTS pattern)
+  metadata     String? // JSON: reagents, solvents, mapped_smiles
 
-  // Reaction Step Data (The "Edge" info)
-  // If this node is a product, how was it made?
-  isLeaf       Boolean @default(false)
-  reactionHash String? // For checking reaction overlap
-  template     String?
-  metadata     String? // JSON: reagents, solvents, mapper output
+  nodes RouteNode[]
+}
+
+model RouteNode {
+  id              String  @id @default(cuid())
+  routeId         String
+  moleculeId      String
+  parentId        String? // Tree structure
+  reactionStepId  String? // null for leaf nodes
+
+  isLeaf Boolean @default(false)
 
   // Relations
-  route    Route       @relation(fields: [routeId], references: [id], onDelete: Cascade)
-  molecule Molecule    @relation(fields: [moleculeId], references: [id])
-  parent   RouteNode?  @relation("ReactionTree", fields: [parentId], references: [id], onDelete: SetNull, onUpdate: NoAction)
-  children RouteNode[] @relation("ReactionTree")
+  route        Route         @relation(fields: [routeId], references: [id], onDelete: Cascade)
+  molecule     Molecule      @relation(fields: [moleculeId], references: [id])
+  reactionStep ReactionStep? @relation(fields: [reactionStepId], references: [id])
+  parent       RouteNode?    @relation("ReactionTree", fields: [parentId], references: [id], onDelete: SetNull, onUpdate: NoAction)
+  children     RouteNode[]   @relation("ReactionTree")
 
   @@index([routeId])
+  @@index([reactionStepId])
 }
 
 // =================================================================================

--- a/scripts/delete-benchmark.ts
+++ b/scripts/delete-benchmark.ts
@@ -10,6 +10,10 @@ import './env-loader'
 
 import { deleteBenchmarkAndDeps } from '../src/lib/services/data/benchmark.data'
 
+if (!process.env.DATABASE_URL) {
+    throw new Error('DATABASE_URL environment variable is not set')
+}
+
 const adapter = new PrismaBetterSqlite3({
     url: process.env.DATABASE_URL,
 })

--- a/scripts/migrate-reaction-steps.ts
+++ b/scripts/migrate-reaction-steps.ts
@@ -51,342 +51,347 @@ function main() {
     }
 
     const db = new Database(DB_PATH)
+    try {
+        // Performance pragmas
+        db.pragma('journal_mode = WAL')
+        db.pragma('synchronous = NORMAL')
+        db.pragma('foreign_keys = OFF') // Re-enabled before verification step
 
-    // Performance pragmas
-    db.pragma('journal_mode = WAL')
-    db.pragma('synchronous = NORMAL')
-    db.pragma('foreign_keys = OFF') // Re-enabled before verification step
+        console.log('\n=== ReactionStep Data Migration ===\n')
 
-    console.log('\n=== ReactionStep Data Migration ===\n')
+        // -----------------------------------------------------------------------
+        // Step 0: Check current state
+        // -----------------------------------------------------------------------
 
-    // -----------------------------------------------------------------------
-    // Step 0: Check current state
-    // -----------------------------------------------------------------------
+        const totalNodes = (db.prepare('SELECT COUNT(*) as cnt FROM RouteNode').get() as { cnt: number }).cnt
+        const nonLeafNodes = (
+            db.prepare('SELECT COUNT(*) as cnt FROM RouteNode WHERE isLeaf = 0').get() as { cnt: number }
+        ).cnt
+        const alreadyLinked = (
+            db.prepare('SELECT COUNT(*) as cnt FROM RouteNode WHERE reactionStepId IS NOT NULL').get() as {
+                cnt: number
+            }
+        ).cnt
+        const existingSteps = (db.prepare('SELECT COUNT(*) as cnt FROM ReactionStep').get() as { cnt: number }).cnt
 
-    const totalNodes = (db.prepare('SELECT COUNT(*) as cnt FROM RouteNode').get() as { cnt: number }).cnt
-    const nonLeafNodes = (db.prepare('SELECT COUNT(*) as cnt FROM RouteNode WHERE isLeaf = 0').get() as { cnt: number })
-        .cnt
-    const alreadyLinked = (
-        db.prepare('SELECT COUNT(*) as cnt FROM RouteNode WHERE reactionStepId IS NOT NULL').get() as {
-            cnt: number
-        }
-    ).cnt
-    const existingSteps = (db.prepare('SELECT COUNT(*) as cnt FROM ReactionStep').get() as { cnt: number }).cnt
+        console.log(`Total RouteNodes:       ${totalNodes.toLocaleString()}`)
+        console.log(`Non-leaf RouteNodes:    ${nonLeafNodes.toLocaleString()}`)
+        console.log(`Already linked:         ${alreadyLinked.toLocaleString()}`)
+        console.log(`Existing ReactionSteps: ${existingSteps.toLocaleString()}`)
+        console.log()
 
-    console.log(`Total RouteNodes:       ${totalNodes.toLocaleString()}`)
-    console.log(`Non-leaf RouteNodes:    ${nonLeafNodes.toLocaleString()}`)
-    console.log(`Already linked:         ${alreadyLinked.toLocaleString()}`)
-    console.log(`Existing ReactionSteps: ${existingSteps.toLocaleString()}`)
-    console.log()
-
-    if (alreadyLinked === nonLeafNodes && existingSteps > 0) {
-        console.log('Migration appears complete. All non-leaf nodes already linked.')
-        console.log('To re-run, clear reactionStepId and ReactionStep table first.')
-        db.close()
-        return
-    }
-
-    const startTime = Date.now()
-
-    // -----------------------------------------------------------------------
-    // Step 1: Build in-memory lookup of parent → children inchikeys
-    //
-    // Strategy: instead of querying children per-node (1.5M queries = slow),
-    // do TWO bulk queries and join in memory.
-    // -----------------------------------------------------------------------
-
-    console.log('Step 1a: Loading node → inchikey mapping...')
-
-    // Map: nodeId → inchikey (for ALL nodes, ~3M entries)
-    const nodeInchikey = new Map<string, string>()
-    const nodeInchikeyQuery = db.prepare(`
-        SELECT rn.id, m.inchikey
-        FROM RouteNode rn
-        JOIN Molecule m ON rn.moleculeId = m.id
-    `)
-
-    let count = 0
-    for (const row of nodeInchikeyQuery.iterate() as Iterable<{ id: string; inchikey: string }>) {
-        nodeInchikey.set(row.id, row.inchikey)
-        count++
-        if (count % 500_000 === 0) {
-            console.log(`  Loaded ${count.toLocaleString()} node→inchikey mappings`)
-        }
-    }
-    console.log(`  Done: ${count.toLocaleString()} mappings loaded (${((Date.now() - startTime) / 1000).toFixed(1)}s)`)
-
-    console.log('\nStep 1b: Loading parent → children relationships...')
-
-    // Map: parentId → [child inchikeys]
-    const parentChildren = new Map<string, string[]>()
-    const childQuery = db.prepare(`
-        SELECT parentId, id as childId
-        FROM RouteNode
-        WHERE parentId IS NOT NULL
-    `)
-
-    count = 0
-    for (const row of childQuery.iterate() as Iterable<{ parentId: string; childId: string }>) {
-        const childInchikey = nodeInchikey.get(row.childId)
-        if (!childInchikey) continue
-
-        let children = parentChildren.get(row.parentId)
-        if (!children) {
-            children = []
-            parentChildren.set(row.parentId, children)
-        }
-        children.push(childInchikey)
-        count++
-        if (count % 500_000 === 0) {
-            console.log(`  Loaded ${count.toLocaleString()} child relationships`)
-        }
-    }
-    console.log(
-        `  Done: ${count.toLocaleString()} relationships loaded (${((Date.now() - startTime) / 1000).toFixed(1)}s)`
-    )
-
-    console.log('\nStep 1c: Loading non-leaf node metadata...')
-
-    // Load template + metadata for non-leaf nodes that still need migration
-    const nonLeafMetaQuery = db.prepare(`
-        SELECT id, template, metadata
-        FROM RouteNode
-        WHERE isLeaf = 0
-          AND reactionStepId IS NULL
-    `)
-
-    interface NodeMeta {
-        id: string
-        template: string | null
-        metadata: string | null
-    }
-
-    const nonLeafMeta = new Map<string, NodeMeta>()
-    for (const row of nonLeafMetaQuery.iterate() as Iterable<NodeMeta>) {
-        nonLeafMeta.set(row.id, row)
-    }
-    console.log(
-        `  Done: ${nonLeafMeta.size.toLocaleString()} non-leaf nodes to process (${((Date.now() - startTime) / 1000).toFixed(1)}s)`
-    )
-
-    // -----------------------------------------------------------------------
-    // Step 1d: Compute reactionHash for each non-leaf node
-    // -----------------------------------------------------------------------
-
-    console.log('\nStep 1d: Computing InChIKey-based reactionHash...')
-
-    interface NodeReaction {
-        nodeId: string
-        reactionHash: string
-        template: string | null
-        metadata: string | null
-    }
-
-    const nodeReactions: NodeReaction[] = []
-    const reactionStepMap = new Map<string, { template: string | null; metadata: string | null }>()
-
-    let processed = 0
-    let skippedNoChildren = 0
-
-    for (const [nodeId, meta] of nonLeafMeta) {
-        const productInchikey = nodeInchikey.get(nodeId)
-        if (!productInchikey) continue
-
-        const reactantInchikeys = parentChildren.get(nodeId)
-        if (!reactantInchikeys || reactantInchikeys.length === 0) {
-            skippedNoChildren++
-            continue
+        if (alreadyLinked === nonLeafNodes && existingSteps > 0) {
+            console.log('Migration appears complete. All non-leaf nodes already linked.')
+            console.log('To re-run, clear reactionStepId and ReactionStep table first.')
+            return
         }
 
-        const hash = computeReactionHash(productInchikey, reactantInchikeys)
+        const startTime = Date.now()
 
-        nodeReactions.push({
-            nodeId,
-            reactionHash: hash,
-            template: meta.template,
-            metadata: meta.metadata,
-        })
+        // -----------------------------------------------------------------------
+        // Step 1: Build in-memory lookup of parent → children inchikeys
+        //
+        // Strategy: instead of querying children per-node (1.5M queries = slow),
+        // do TWO bulk queries and join in memory.
+        // -----------------------------------------------------------------------
 
-        // Store template/metadata for the first occurrence of each unique reaction
-        if (!reactionStepMap.has(hash)) {
-            reactionStepMap.set(hash, {
+        console.log('Step 1a: Loading node → inchikey mapping...')
+
+        // Map: nodeId → inchikey (for ALL nodes, ~3M entries)
+        const nodeInchikey = new Map<string, string>()
+        const nodeInchikeyQuery = db.prepare(`
+            SELECT rn.id, m.inchikey
+            FROM RouteNode rn
+            JOIN Molecule m ON rn.moleculeId = m.id
+        `)
+
+        let count = 0
+        for (const row of nodeInchikeyQuery.iterate() as Iterable<{ id: string; inchikey: string }>) {
+            nodeInchikey.set(row.id, row.inchikey)
+            count++
+            if (count % 500_000 === 0) {
+                console.log(`  Loaded ${count.toLocaleString()} node→inchikey mappings`)
+            }
+        }
+        console.log(
+            `  Done: ${count.toLocaleString()} mappings loaded (${((Date.now() - startTime) / 1000).toFixed(1)}s)`
+        )
+
+        console.log('\nStep 1b: Loading parent → children relationships...')
+
+        // Map: parentId → [child inchikeys]
+        const parentChildren = new Map<string, string[]>()
+        const childQuery = db.prepare(`
+            SELECT parentId, id as childId
+            FROM RouteNode
+            WHERE parentId IS NOT NULL
+        `)
+
+        count = 0
+        for (const row of childQuery.iterate() as Iterable<{ parentId: string; childId: string }>) {
+            const childInchikey = nodeInchikey.get(row.childId)
+            if (!childInchikey) continue
+
+            let children = parentChildren.get(row.parentId)
+            if (!children) {
+                children = []
+                parentChildren.set(row.parentId, children)
+            }
+            children.push(childInchikey)
+            count++
+            if (count % 500_000 === 0) {
+                console.log(`  Loaded ${count.toLocaleString()} child relationships`)
+            }
+        }
+        console.log(
+            `  Done: ${count.toLocaleString()} relationships loaded (${((Date.now() - startTime) / 1000).toFixed(1)}s)`
+        )
+
+        console.log('\nStep 1c: Loading non-leaf node metadata...')
+
+        // Load template + metadata for non-leaf nodes that still need migration
+        const nonLeafMetaQuery = db.prepare(`
+            SELECT id, template, metadata
+            FROM RouteNode
+            WHERE isLeaf = 0
+              AND reactionStepId IS NULL
+        `)
+
+        interface NodeMeta {
+            id: string
+            template: string | null
+            metadata: string | null
+        }
+
+        const nonLeafMeta = new Map<string, NodeMeta>()
+        for (const row of nonLeafMetaQuery.iterate() as Iterable<NodeMeta>) {
+            nonLeafMeta.set(row.id, row)
+        }
+        console.log(
+            `  Done: ${nonLeafMeta.size.toLocaleString()} non-leaf nodes to process (${((Date.now() - startTime) / 1000).toFixed(1)}s)`
+        )
+
+        // -----------------------------------------------------------------------
+        // Step 1d: Compute reactionHash for each non-leaf node
+        // -----------------------------------------------------------------------
+
+        console.log('\nStep 1d: Computing InChIKey-based reactionHash...')
+
+        interface NodeReaction {
+            nodeId: string
+            reactionHash: string
+            template: string | null
+            metadata: string | null
+        }
+
+        const nodeReactions: NodeReaction[] = []
+        const reactionStepMap = new Map<string, { template: string | null; metadata: string | null }>()
+
+        let processed = 0
+        let skippedNoChildren = 0
+
+        for (const [nodeId, meta] of nonLeafMeta) {
+            const productInchikey = nodeInchikey.get(nodeId)
+            if (!productInchikey) continue
+
+            const reactantInchikeys = parentChildren.get(nodeId)
+            if (!reactantInchikeys || reactantInchikeys.length === 0) {
+                skippedNoChildren++
+                continue
+            }
+
+            const hash = computeReactionHash(productInchikey, reactantInchikeys)
+
+            nodeReactions.push({
+                nodeId,
+                reactionHash: hash,
                 template: meta.template,
                 metadata: meta.metadata,
             })
+
+            // Store template/metadata for the first occurrence of each unique reaction
+            if (!reactionStepMap.has(hash)) {
+                reactionStepMap.set(hash, {
+                    template: meta.template,
+                    metadata: meta.metadata,
+                })
+            }
+
+            processed++
+            if (processed % 250_000 === 0) {
+                const elapsed = ((Date.now() - startTime) / 1000).toFixed(1)
+                console.log(`  Computed ${processed.toLocaleString()} hashes (${elapsed}s)`)
+            }
         }
 
-        processed++
-        if (processed % 250_000 === 0) {
+        // Free memory from bulk lookups
+        nodeInchikey.clear()
+        parentChildren.clear()
+        nonLeafMeta.clear()
+
+        const step1Elapsed = ((Date.now() - startTime) / 1000).toFixed(1)
+        console.log(
+            `  Done: ${processed.toLocaleString()} nodes -> ${reactionStepMap.size.toLocaleString()} unique reactions (${step1Elapsed}s)`
+        )
+        if (skippedNoChildren > 0) {
+            console.log(`  Skipped ${skippedNoChildren} non-leaf nodes with no children (data integrity issue)`)
+        }
+
+        // -----------------------------------------------------------------------
+        // Step 2: Insert unique ReactionStep records
+        // -----------------------------------------------------------------------
+
+        console.log('\nStep 2: Inserting ReactionStep records...')
+
+        const insertStep = db.prepare(`
+            INSERT OR IGNORE INTO ReactionStep (id, reactionHash, template, metadata)
+            VALUES (?, ?, ?, ?)
+        `)
+
+        // Build hash -> id map (check existing first)
+        const hashToId = new Map<string, string>()
+
+        // Load any existing ReactionStep records (for idempotency)
+        const existingStepsRows = db.prepare('SELECT id, reactionHash FROM ReactionStep').all() as {
+            id: string
+            reactionHash: string
+        }[]
+        for (const row of existingStepsRows) {
+            hashToId.set(row.reactionHash, row.id)
+        }
+        if (existingStepsRows.length > 0) {
+            console.log(`  Found ${existingStepsRows.length.toLocaleString()} existing ReactionStep records`)
+        }
+
+        // Insert new ones in batched transactions
+        let insertedCount = 0
+        const insertTransaction = db.transaction(
+            (entries: [string, { template: string | null; metadata: string | null }][]) => {
+                for (const [hash, data] of entries) {
+                    if (hashToId.has(hash)) continue
+
+                    const id = createId()
+                    insertStep.run(id, hash, data.template, data.metadata)
+                    hashToId.set(hash, id)
+                    insertedCount++
+                }
+            }
+        )
+
+        const entries = Array.from(reactionStepMap.entries())
+        for (let i = 0; i < entries.length; i += BATCH_SIZE) {
+            const batch = entries.slice(i, i + BATCH_SIZE)
+            insertTransaction(batch)
             const elapsed = ((Date.now() - startTime) / 1000).toFixed(1)
-            console.log(`  Computed ${processed.toLocaleString()} hashes (${elapsed}s)`)
-        }
-    }
-
-    // Free memory from bulk lookups
-    nodeInchikey.clear()
-    parentChildren.clear()
-    nonLeafMeta.clear()
-
-    const step1Elapsed = ((Date.now() - startTime) / 1000).toFixed(1)
-    console.log(
-        `  Done: ${processed.toLocaleString()} nodes -> ${reactionStepMap.size.toLocaleString()} unique reactions (${step1Elapsed}s)`
-    )
-    if (skippedNoChildren > 0) {
-        console.log(`  Skipped ${skippedNoChildren} non-leaf nodes with no children (data integrity issue)`)
-    }
-
-    // -----------------------------------------------------------------------
-    // Step 2: Insert unique ReactionStep records
-    // -----------------------------------------------------------------------
-
-    console.log('\nStep 2: Inserting ReactionStep records...')
-
-    const insertStep = db.prepare(`
-        INSERT OR IGNORE INTO ReactionStep (id, reactionHash, template, metadata)
-        VALUES (?, ?, ?, ?)
-    `)
-
-    // Build hash -> id map (check existing first)
-    const hashToId = new Map<string, string>()
-
-    // Load any existing ReactionStep records (for idempotency)
-    const existingStepsRows = db.prepare('SELECT id, reactionHash FROM ReactionStep').all() as {
-        id: string
-        reactionHash: string
-    }[]
-    for (const row of existingStepsRows) {
-        hashToId.set(row.reactionHash, row.id)
-    }
-    if (existingStepsRows.length > 0) {
-        console.log(`  Found ${existingStepsRows.length.toLocaleString()} existing ReactionStep records`)
-    }
-
-    // Insert new ones in batched transactions
-    let insertedCount = 0
-    const insertTransaction = db.transaction(
-        (entries: [string, { template: string | null; metadata: string | null }][]) => {
-            for (const [hash, data] of entries) {
-                if (hashToId.has(hash)) continue
-
-                const id = createId()
-                insertStep.run(id, hash, data.template, data.metadata)
-                hashToId.set(hash, id)
-                insertedCount++
-            }
-        }
-    )
-
-    const entries = Array.from(reactionStepMap.entries())
-    for (let i = 0; i < entries.length; i += BATCH_SIZE) {
-        const batch = entries.slice(i, i + BATCH_SIZE)
-        insertTransaction(batch)
-        const elapsed = ((Date.now() - startTime) / 1000).toFixed(1)
-        console.log(
-            `  Batch ${Math.floor(i / BATCH_SIZE) + 1}: ${Math.min(i + BATCH_SIZE, entries.length).toLocaleString()} / ${entries.length.toLocaleString()} (${elapsed}s)`
-        )
-    }
-
-    console.log(`  Done: ${insertedCount.toLocaleString()} new ReactionStep records inserted`)
-
-    // Free memory
-    reactionStepMap.clear()
-
-    // -----------------------------------------------------------------------
-    // Step 3: Update RouteNode.reactionStepId
-    // -----------------------------------------------------------------------
-
-    console.log('\nStep 3: Updating RouteNode.reactionStepId...')
-
-    const updateNode = db.prepare(`
-        UPDATE RouteNode SET reactionStepId = ? WHERE id = ?
-    `)
-
-    let updatedCount = 0
-    const updateStartTime = Date.now()
-
-    const updateTransaction = db.transaction((batch: NodeReaction[]) => {
-        for (const nr of batch) {
-            const stepId = hashToId.get(nr.reactionHash)
-            if (!stepId) {
-                console.error(`  ERROR: No ReactionStep found for hash ${nr.reactionHash} (node ${nr.nodeId})`)
-                continue
-            }
-            updateNode.run(stepId, nr.nodeId)
-            updatedCount++
-        }
-    })
-
-    for (let i = 0; i < nodeReactions.length; i += BATCH_SIZE) {
-        const batch = nodeReactions.slice(i, i + BATCH_SIZE)
-        updateTransaction(batch)
-        const elapsed = ((Date.now() - updateStartTime) / 1000).toFixed(1)
-        console.log(
-            `  Batch ${Math.floor(i / BATCH_SIZE) + 1}: ${Math.min(i + BATCH_SIZE, nodeReactions.length).toLocaleString()} / ${nodeReactions.length.toLocaleString()} (${elapsed}s)`
-        )
-    }
-
-    const step3Elapsed = ((Date.now() - updateStartTime) / 1000).toFixed(1)
-    console.log(`  Done: ${updatedCount.toLocaleString()} RouteNodes updated (${step3Elapsed}s)`)
-
-    // -----------------------------------------------------------------------
-    // Step 4: Verify
-    // -----------------------------------------------------------------------
-
-    // Re-enable foreign key enforcement before verification
-    db.pragma('foreign_keys = ON')
-
-    console.log('\nStep 4: Verification...')
-
-    const finalSteps = (db.prepare('SELECT COUNT(*) as cnt FROM ReactionStep').get() as { cnt: number }).cnt
-    const finalLinked = (
-        db.prepare('SELECT COUNT(*) as cnt FROM RouteNode WHERE reactionStepId IS NOT NULL').get() as {
-            cnt: number
-        }
-    ).cnt
-    const unlinkedNonLeaf = (
-        db.prepare('SELECT COUNT(*) as cnt FROM RouteNode WHERE isLeaf = 0 AND reactionStepId IS NULL').get() as {
-            cnt: number
-        }
-    ).cnt
-    const leafWithStep = (
-        db.prepare('SELECT COUNT(*) as cnt FROM RouteNode WHERE isLeaf = 1 AND reactionStepId IS NOT NULL').get() as {
-            cnt: number
-        }
-    ).cnt
-
-    console.log(`  ReactionStep records:         ${finalSteps.toLocaleString()}`)
-    console.log(`  RouteNodes with reactionStep: ${finalLinked.toLocaleString()}`)
-    console.log(`  Unlinked non-leaf nodes:      ${unlinkedNonLeaf.toLocaleString()}`)
-    console.log(`  Leaf nodes with step (bug?):  ${leafWithStep.toLocaleString()}`)
-
-    if (unlinkedNonLeaf > 0) {
-        console.log(
-            '\n  WARNING: Some non-leaf nodes were not linked. These may be nodes with no children (data integrity issue).'
-        )
-        const examples = db
-            .prepare(
-                `SELECT rn.id, rn.routeId, m.smiles
-                 FROM RouteNode rn
-                 JOIN Molecule m ON rn.moleculeId = m.id
-                 WHERE rn.isLeaf = 0 AND rn.reactionStepId IS NULL
-                 LIMIT 5`
+            console.log(
+                `  Batch ${Math.floor(i / BATCH_SIZE) + 1}: ${Math.min(i + BATCH_SIZE, entries.length).toLocaleString()} / ${entries.length.toLocaleString()} (${elapsed}s)`
             )
-            .all() as { id: string; routeId: string; smiles: string }[]
-        for (const ex of examples) {
-            console.log(`    Node ${ex.id} (route ${ex.routeId}): ${ex.smiles}`)
         }
+
+        console.log(`  Done: ${insertedCount.toLocaleString()} new ReactionStep records inserted`)
+
+        // Free memory
+        reactionStepMap.clear()
+
+        // -----------------------------------------------------------------------
+        // Step 3: Update RouteNode.reactionStepId
+        // -----------------------------------------------------------------------
+
+        console.log('\nStep 3: Updating RouteNode.reactionStepId...')
+
+        const updateNode = db.prepare(`
+            UPDATE RouteNode SET reactionStepId = ? WHERE id = ?
+        `)
+
+        let updatedCount = 0
+        const updateStartTime = Date.now()
+
+        const updateTransaction = db.transaction((batch: NodeReaction[]) => {
+            for (const nr of batch) {
+                const stepId = hashToId.get(nr.reactionHash)
+                if (!stepId) {
+                    console.error(`  ERROR: No ReactionStep found for hash ${nr.reactionHash} (node ${nr.nodeId})`)
+                    continue
+                }
+                updateNode.run(stepId, nr.nodeId)
+                updatedCount++
+            }
+        })
+
+        for (let i = 0; i < nodeReactions.length; i += BATCH_SIZE) {
+            const batch = nodeReactions.slice(i, i + BATCH_SIZE)
+            updateTransaction(batch)
+            const elapsed = ((Date.now() - updateStartTime) / 1000).toFixed(1)
+            console.log(
+                `  Batch ${Math.floor(i / BATCH_SIZE) + 1}: ${Math.min(i + BATCH_SIZE, nodeReactions.length).toLocaleString()} / ${nodeReactions.length.toLocaleString()} (${elapsed}s)`
+            )
+        }
+
+        const step3Elapsed = ((Date.now() - updateStartTime) / 1000).toFixed(1)
+        console.log(`  Done: ${updatedCount.toLocaleString()} RouteNodes updated (${step3Elapsed}s)`)
+
+        // -----------------------------------------------------------------------
+        // Step 4: Verify
+        // -----------------------------------------------------------------------
+
+        // Re-enable foreign key enforcement before verification
+        db.pragma('foreign_keys = ON')
+
+        console.log('\nStep 4: Verification...')
+
+        const finalSteps = (db.prepare('SELECT COUNT(*) as cnt FROM ReactionStep').get() as { cnt: number }).cnt
+        const finalLinked = (
+            db.prepare('SELECT COUNT(*) as cnt FROM RouteNode WHERE reactionStepId IS NOT NULL').get() as {
+                cnt: number
+            }
+        ).cnt
+        const unlinkedNonLeaf = (
+            db.prepare('SELECT COUNT(*) as cnt FROM RouteNode WHERE isLeaf = 0 AND reactionStepId IS NULL').get() as {
+                cnt: number
+            }
+        ).cnt
+        const leafWithStep = (
+            db
+                .prepare('SELECT COUNT(*) as cnt FROM RouteNode WHERE isLeaf = 1 AND reactionStepId IS NOT NULL')
+                .get() as {
+                cnt: number
+            }
+        ).cnt
+
+        console.log(`  ReactionStep records:         ${finalSteps.toLocaleString()}`)
+        console.log(`  RouteNodes with reactionStep: ${finalLinked.toLocaleString()}`)
+        console.log(`  Unlinked non-leaf nodes:      ${unlinkedNonLeaf.toLocaleString()}`)
+        console.log(`  Leaf nodes with step (bug?):  ${leafWithStep.toLocaleString()}`)
+
+        if (unlinkedNonLeaf > 0) {
+            console.log(
+                '\n  WARNING: Some non-leaf nodes were not linked. These may be nodes with no children (data integrity issue).'
+            )
+            const examples = db
+                .prepare(
+                    `SELECT rn.id, rn.routeId, m.smiles
+                     FROM RouteNode rn
+                     JOIN Molecule m ON rn.moleculeId = m.id
+                     WHERE rn.isLeaf = 0 AND rn.reactionStepId IS NULL
+                     LIMIT 5`
+                )
+                .all() as { id: string; routeId: string; smiles: string }[]
+            for (const ex of examples) {
+                console.log(`    Node ${ex.id} (route ${ex.routeId}): ${ex.smiles}`)
+            }
+        }
+
+        // Deduplication stats
+        const dedupRatio = finalSteps > 0 ? nonLeafNodes / finalSteps : 0
+        console.log(
+            `\n  Deduplication ratio: ${dedupRatio.toFixed(1)}x (${nonLeafNodes.toLocaleString()} non-leaf nodes -> ${finalSteps.toLocaleString()} unique ReactionSteps)`
+        )
+
+        const totalElapsed = ((Date.now() - startTime) / 1000).toFixed(1)
+        console.log(`\n=== Migration complete in ${totalElapsed}s ===`)
+    } finally {
+        db.close()
     }
-
-    // Deduplication stats
-    const dedupRatio = finalSteps > 0 ? nonLeafNodes / finalSteps : 0
-    console.log(
-        `\n  Deduplication ratio: ${dedupRatio.toFixed(1)}x (${nonLeafNodes.toLocaleString()} non-leaf nodes -> ${finalSteps.toLocaleString()} unique ReactionSteps)`
-    )
-
-    const totalElapsed = ((Date.now() - startTime) / 1000).toFixed(1)
-    console.log(`\n=== Migration complete in ${totalElapsed}s ===`)
-
-    db.close()
 }
 
 main()

--- a/scripts/migrate-reaction-steps.ts
+++ b/scripts/migrate-reaction-steps.ts
@@ -1,0 +1,384 @@
+#!/usr/bin/env tsx
+
+/**
+ * Data migration: Populate ReactionStep table and backfill RouteNode.reactionStepId.
+ *
+ * This script:
+ * 1. Recomputes reactionHash using InChIKeys (not SMILES) for all non-leaf RouteNodes
+ * 2. Extracts unique (reactionHash, template, metadata) into ReactionStep records
+ * 3. Sets RouteNode.reactionStepId to point to the corresponding ReactionStep
+ *
+ * Uses raw better-sqlite3 for performance (~3M rows).
+ * Idempotent: safe to re-run if interrupted.
+ *
+ * Usage:
+ *   pnpm tsx scripts/migrate-reaction-steps.ts
+ */
+import crypto from 'node:crypto'
+import Database from 'better-sqlite3'
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const DB_PATH = 'prisma/dev.db'
+const BATCH_SIZE = 50_000
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function computeReactionHash(productInchikey: string, reactantInchikeys: string[]): string {
+    const sorted = [...reactantInchikeys].sort()
+    const content = `${productInchikey}>>${sorted.join('.')}`
+    return crypto.createHash('sha256').update(content).digest('hex')
+}
+
+function generateCuid(): string {
+    const timestamp = Date.now().toString(36)
+    const random = crypto.randomBytes(8).toString('hex')
+    return `rs_${timestamp}${random}`
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main() {
+    const db = new Database(DB_PATH)
+
+    // Performance pragmas
+    db.pragma('journal_mode = WAL')
+    db.pragma('synchronous = NORMAL')
+    db.pragma('foreign_keys = OFF')
+
+    console.log('=== ReactionStep Data Migration ===\n')
+
+    // -----------------------------------------------------------------------
+    // Step 0: Check current state
+    // -----------------------------------------------------------------------
+
+    const totalNodes = (db.prepare('SELECT COUNT(*) as cnt FROM RouteNode').get() as { cnt: number }).cnt
+    const nonLeafNodes = (db.prepare('SELECT COUNT(*) as cnt FROM RouteNode WHERE isLeaf = 0').get() as { cnt: number })
+        .cnt
+    const alreadyLinked = (
+        db.prepare('SELECT COUNT(*) as cnt FROM RouteNode WHERE reactionStepId IS NOT NULL').get() as {
+            cnt: number
+        }
+    ).cnt
+    const existingSteps = (db.prepare('SELECT COUNT(*) as cnt FROM ReactionStep').get() as { cnt: number }).cnt
+
+    console.log(`Total RouteNodes:       ${totalNodes.toLocaleString()}`)
+    console.log(`Non-leaf RouteNodes:    ${nonLeafNodes.toLocaleString()}`)
+    console.log(`Already linked:         ${alreadyLinked.toLocaleString()}`)
+    console.log(`Existing ReactionSteps: ${existingSteps.toLocaleString()}`)
+    console.log()
+
+    if (alreadyLinked === nonLeafNodes && existingSteps > 0) {
+        console.log('Migration appears complete. All non-leaf nodes already linked.')
+        console.log('To re-run, clear reactionStepId and ReactionStep table first.')
+        db.close()
+        return
+    }
+
+    const startTime = Date.now()
+
+    // -----------------------------------------------------------------------
+    // Step 1: Build in-memory lookup of parent → children inchikeys
+    //
+    // Strategy: instead of querying children per-node (1.5M queries = slow),
+    // do TWO bulk queries and join in memory.
+    // -----------------------------------------------------------------------
+
+    console.log('Step 1a: Loading node → inchikey mapping...')
+
+    // Map: nodeId → inchikey (for ALL nodes, ~3M entries)
+    const nodeInchikey = new Map<string, string>()
+    const nodeInchikeyQuery = db.prepare(`
+        SELECT rn.id, m.inchikey
+        FROM RouteNode rn
+        JOIN Molecule m ON rn.moleculeId = m.id
+    `)
+
+    let count = 0
+    for (const row of nodeInchikeyQuery.iterate() as Iterable<{ id: string; inchikey: string }>) {
+        nodeInchikey.set(row.id, row.inchikey)
+        count++
+        if (count % 500_000 === 0) {
+            console.log(`  Loaded ${count.toLocaleString()} node→inchikey mappings`)
+        }
+    }
+    console.log(`  Done: ${count.toLocaleString()} mappings loaded (${((Date.now() - startTime) / 1000).toFixed(1)}s)`)
+
+    console.log('\nStep 1b: Loading parent → children relationships...')
+
+    // Map: parentId → [child inchikeys]
+    const parentChildren = new Map<string, string[]>()
+    const childQuery = db.prepare(`
+        SELECT parentId, id as childId
+        FROM RouteNode
+        WHERE parentId IS NOT NULL
+    `)
+
+    count = 0
+    for (const row of childQuery.iterate() as Iterable<{ parentId: string; childId: string }>) {
+        const childInchikey = nodeInchikey.get(row.childId)
+        if (!childInchikey) continue
+
+        let children = parentChildren.get(row.parentId)
+        if (!children) {
+            children = []
+            parentChildren.set(row.parentId, children)
+        }
+        children.push(childInchikey)
+        count++
+        if (count % 500_000 === 0) {
+            console.log(`  Loaded ${count.toLocaleString()} child relationships`)
+        }
+    }
+    console.log(
+        `  Done: ${count.toLocaleString()} relationships loaded (${((Date.now() - startTime) / 1000).toFixed(1)}s)`
+    )
+
+    console.log('\nStep 1c: Loading non-leaf node metadata...')
+
+    // Load template + metadata for non-leaf nodes that still need migration
+    const nonLeafMetaQuery = db.prepare(`
+        SELECT id, template, metadata
+        FROM RouteNode
+        WHERE isLeaf = 0
+          AND reactionStepId IS NULL
+    `)
+
+    interface NodeMeta {
+        id: string
+        template: string | null
+        metadata: string | null
+    }
+
+    const nonLeafMeta = new Map<string, NodeMeta>()
+    for (const row of nonLeafMetaQuery.iterate() as Iterable<NodeMeta>) {
+        nonLeafMeta.set(row.id, row)
+    }
+    console.log(
+        `  Done: ${nonLeafMeta.size.toLocaleString()} non-leaf nodes to process (${((Date.now() - startTime) / 1000).toFixed(1)}s)`
+    )
+
+    // -----------------------------------------------------------------------
+    // Step 1d: Compute reactionHash for each non-leaf node
+    // -----------------------------------------------------------------------
+
+    console.log('\nStep 1d: Computing InChIKey-based reactionHash...')
+
+    interface NodeReaction {
+        nodeId: string
+        reactionHash: string
+        template: string | null
+        metadata: string | null
+    }
+
+    const nodeReactions: NodeReaction[] = []
+    const reactionStepMap = new Map<string, { template: string | null; metadata: string | null }>()
+
+    let processed = 0
+    let skippedNoChildren = 0
+
+    for (const [nodeId, meta] of nonLeafMeta) {
+        const productInchikey = nodeInchikey.get(nodeId)
+        if (!productInchikey) continue
+
+        const reactantInchikeys = parentChildren.get(nodeId)
+        if (!reactantInchikeys || reactantInchikeys.length === 0) {
+            skippedNoChildren++
+            continue
+        }
+
+        const hash = computeReactionHash(productInchikey, reactantInchikeys)
+
+        nodeReactions.push({
+            nodeId,
+            reactionHash: hash,
+            template: meta.template,
+            metadata: meta.metadata,
+        })
+
+        // Store template/metadata for the first occurrence of each unique reaction
+        if (!reactionStepMap.has(hash)) {
+            reactionStepMap.set(hash, {
+                template: meta.template,
+                metadata: meta.metadata,
+            })
+        }
+
+        processed++
+        if (processed % 250_000 === 0) {
+            const elapsed = ((Date.now() - startTime) / 1000).toFixed(1)
+            console.log(`  Computed ${processed.toLocaleString()} hashes (${elapsed}s)`)
+        }
+    }
+
+    // Free memory from bulk lookups
+    nodeInchikey.clear()
+    parentChildren.clear()
+    nonLeafMeta.clear()
+
+    const step1Elapsed = ((Date.now() - startTime) / 1000).toFixed(1)
+    console.log(
+        `  Done: ${processed.toLocaleString()} nodes -> ${reactionStepMap.size.toLocaleString()} unique reactions (${step1Elapsed}s)`
+    )
+    if (skippedNoChildren > 0) {
+        console.log(`  Skipped ${skippedNoChildren} non-leaf nodes with no children (data integrity issue)`)
+    }
+
+    // -----------------------------------------------------------------------
+    // Step 2: Insert unique ReactionStep records
+    // -----------------------------------------------------------------------
+
+    console.log('\nStep 2: Inserting ReactionStep records...')
+
+    const insertStep = db.prepare(`
+        INSERT OR IGNORE INTO ReactionStep (id, reactionHash, template, metadata)
+        VALUES (?, ?, ?, ?)
+    `)
+
+    // Build hash -> id map (check existing first)
+    const hashToId = new Map<string, string>()
+
+    // Load any existing ReactionStep records (for idempotency)
+    const existingStepsRows = db.prepare('SELECT id, reactionHash FROM ReactionStep').all() as {
+        id: string
+        reactionHash: string
+    }[]
+    for (const row of existingStepsRows) {
+        hashToId.set(row.reactionHash, row.id)
+    }
+    if (existingStepsRows.length > 0) {
+        console.log(`  Found ${existingStepsRows.length.toLocaleString()} existing ReactionStep records`)
+    }
+
+    // Insert new ones in batched transactions
+    let insertedCount = 0
+    const insertTransaction = db.transaction(
+        (entries: [string, { template: string | null; metadata: string | null }][]) => {
+            for (const [hash, data] of entries) {
+                if (hashToId.has(hash)) continue
+
+                const id = generateCuid()
+                insertStep.run(id, hash, data.template, data.metadata)
+                hashToId.set(hash, id)
+                insertedCount++
+            }
+        }
+    )
+
+    const entries = Array.from(reactionStepMap.entries())
+    for (let i = 0; i < entries.length; i += BATCH_SIZE) {
+        const batch = entries.slice(i, i + BATCH_SIZE)
+        insertTransaction(batch)
+        const elapsed = ((Date.now() - startTime) / 1000).toFixed(1)
+        console.log(
+            `  Batch ${Math.floor(i / BATCH_SIZE) + 1}: ${Math.min(i + BATCH_SIZE, entries.length).toLocaleString()} / ${entries.length.toLocaleString()} (${elapsed}s)`
+        )
+    }
+
+    console.log(`  Done: ${insertedCount.toLocaleString()} new ReactionStep records inserted`)
+
+    // Free memory
+    reactionStepMap.clear()
+
+    // -----------------------------------------------------------------------
+    // Step 3: Update RouteNode.reactionStepId
+    // -----------------------------------------------------------------------
+
+    console.log('\nStep 3: Updating RouteNode.reactionStepId...')
+
+    const updateNode = db.prepare(`
+        UPDATE RouteNode SET reactionStepId = ? WHERE id = ?
+    `)
+
+    let updatedCount = 0
+    const updateStartTime = Date.now()
+
+    const updateTransaction = db.transaction((batch: NodeReaction[]) => {
+        for (const nr of batch) {
+            const stepId = hashToId.get(nr.reactionHash)
+            if (!stepId) {
+                console.error(`  ERROR: No ReactionStep found for hash ${nr.reactionHash} (node ${nr.nodeId})`)
+                continue
+            }
+            updateNode.run(stepId, nr.nodeId)
+            updatedCount++
+        }
+    })
+
+    for (let i = 0; i < nodeReactions.length; i += BATCH_SIZE) {
+        const batch = nodeReactions.slice(i, i + BATCH_SIZE)
+        updateTransaction(batch)
+        const elapsed = ((Date.now() - updateStartTime) / 1000).toFixed(1)
+        console.log(
+            `  Batch ${Math.floor(i / BATCH_SIZE) + 1}: ${Math.min(i + BATCH_SIZE, nodeReactions.length).toLocaleString()} / ${nodeReactions.length.toLocaleString()} (${elapsed}s)`
+        )
+    }
+
+    const step3Elapsed = ((Date.now() - updateStartTime) / 1000).toFixed(1)
+    console.log(`  Done: ${updatedCount.toLocaleString()} RouteNodes updated (${step3Elapsed}s)`)
+
+    // -----------------------------------------------------------------------
+    // Step 4: Verify
+    // -----------------------------------------------------------------------
+
+    console.log('\nStep 4: Verification...')
+
+    const finalSteps = (db.prepare('SELECT COUNT(*) as cnt FROM ReactionStep').get() as { cnt: number }).cnt
+    const finalLinked = (
+        db.prepare('SELECT COUNT(*) as cnt FROM RouteNode WHERE reactionStepId IS NOT NULL').get() as {
+            cnt: number
+        }
+    ).cnt
+    const unlinkedNonLeaf = (
+        db.prepare('SELECT COUNT(*) as cnt FROM RouteNode WHERE isLeaf = 0 AND reactionStepId IS NULL').get() as {
+            cnt: number
+        }
+    ).cnt
+    const leafWithStep = (
+        db.prepare('SELECT COUNT(*) as cnt FROM RouteNode WHERE isLeaf = 1 AND reactionStepId IS NOT NULL').get() as {
+            cnt: number
+        }
+    ).cnt
+
+    console.log(`  ReactionStep records:         ${finalSteps.toLocaleString()}`)
+    console.log(`  RouteNodes with reactionStep: ${finalLinked.toLocaleString()}`)
+    console.log(`  Unlinked non-leaf nodes:      ${unlinkedNonLeaf.toLocaleString()}`)
+    console.log(`  Leaf nodes with step (bug?):  ${leafWithStep.toLocaleString()}`)
+
+    if (unlinkedNonLeaf > 0) {
+        console.log(
+            '\n  WARNING: Some non-leaf nodes were not linked. These may be nodes with no children (data integrity issue).'
+        )
+        const examples = db
+            .prepare(
+                `SELECT rn.id, rn.routeId, m.smiles
+                 FROM RouteNode rn
+                 JOIN Molecule m ON rn.moleculeId = m.id
+                 WHERE rn.isLeaf = 0 AND rn.reactionStepId IS NULL
+                 LIMIT 5`
+            )
+            .all() as { id: string; routeId: string; smiles: string }[]
+        for (const ex of examples) {
+            console.log(`    Node ${ex.id} (route ${ex.routeId}): ${ex.smiles}`)
+        }
+    }
+
+    // Deduplication stats
+    const dedupRatio = nonLeafNodes / finalSteps
+    console.log(
+        `\n  Deduplication ratio: ${dedupRatio.toFixed(1)}x (${nonLeafNodes.toLocaleString()} non-leaf nodes -> ${finalSteps.toLocaleString()} unique ReactionSteps)`
+    )
+
+    const totalElapsed = ((Date.now() - startTime) / 1000).toFixed(1)
+    console.log(`\n=== Migration complete in ${totalElapsed}s ===`)
+
+    db.close()
+}
+
+main()

--- a/scripts/migrate-reaction-steps.ts
+++ b/scripts/migrate-reaction-steps.ts
@@ -40,18 +40,18 @@ function computeReactionHash(productInchikey: string, reactantInchikeys: string[
 // Main
 // ---------------------------------------------------------------------------
 
-function main() {
-    // Create backup before migration
+async function main() {
     const backupPath = DB_PATH + '.backup-before-reaction-step'
-    if (!fs.existsSync(backupPath)) {
-        console.log(`Backing up database to ${backupPath}...`)
-        fs.copyFileSync(DB_PATH, backupPath)
-    } else {
-        console.log(`Backup already exists at ${backupPath}, skipping.`)
-    }
-
     const db = new Database(DB_PATH)
     try {
+        // Use SQLite's backup API so WAL-backed changes are included.
+        if (!fs.existsSync(backupPath)) {
+            console.log(`Backing up database to ${backupPath}...`)
+            await db.backup(backupPath)
+        } else {
+            console.log(`Backup already exists at ${backupPath}, skipping.`)
+        }
+
         // Performance pragmas
         db.pragma('journal_mode = WAL')
         db.pragma('synchronous = NORMAL')
@@ -394,4 +394,7 @@ function main() {
     }
 }
 
-main()
+void main().catch((error: unknown) => {
+    console.error(error)
+    process.exitCode = 1
+})

--- a/scripts/migrate-reaction-steps.ts
+++ b/scripts/migrate-reaction-steps.ts
@@ -15,6 +15,8 @@
  *   pnpm tsx scripts/migrate-reaction-steps.ts
  */
 import crypto from 'node:crypto'
+import fs from 'node:fs'
+import { createId } from '@paralleldrive/cuid2'
 import Database from 'better-sqlite3'
 
 // ---------------------------------------------------------------------------
@@ -34,25 +36,28 @@ function computeReactionHash(productInchikey: string, reactantInchikeys: string[
     return crypto.createHash('sha256').update(content).digest('hex')
 }
 
-function generateCuid(): string {
-    const timestamp = Date.now().toString(36)
-    const random = crypto.randomBytes(8).toString('hex')
-    return `rs_${timestamp}${random}`
-}
-
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
 function main() {
+    // Create backup before migration
+    const backupPath = DB_PATH + '.backup-before-reaction-step'
+    if (!fs.existsSync(backupPath)) {
+        console.log(`Backing up database to ${backupPath}...`)
+        fs.copyFileSync(DB_PATH, backupPath)
+    } else {
+        console.log(`Backup already exists at ${backupPath}, skipping.`)
+    }
+
     const db = new Database(DB_PATH)
 
     // Performance pragmas
     db.pragma('journal_mode = WAL')
     db.pragma('synchronous = NORMAL')
-    db.pragma('foreign_keys = OFF')
+    db.pragma('foreign_keys = OFF') // Re-enabled before verification step
 
-    console.log('=== ReactionStep Data Migration ===\n')
+    console.log('\n=== ReactionStep Data Migration ===\n')
 
     // -----------------------------------------------------------------------
     // Step 0: Check current state
@@ -263,7 +268,7 @@ function main() {
             for (const [hash, data] of entries) {
                 if (hashToId.has(hash)) continue
 
-                const id = generateCuid()
+                const id = createId()
                 insertStep.run(id, hash, data.template, data.metadata)
                 hashToId.set(hash, id)
                 insertedCount++
@@ -327,6 +332,9 @@ function main() {
     // Step 4: Verify
     // -----------------------------------------------------------------------
 
+    // Re-enable foreign key enforcement before verification
+    db.pragma('foreign_keys = ON')
+
     console.log('\nStep 4: Verification...')
 
     const finalSteps = (db.prepare('SELECT COUNT(*) as cnt FROM ReactionStep').get() as { cnt: number }).cnt
@@ -370,7 +378,7 @@ function main() {
     }
 
     // Deduplication stats
-    const dedupRatio = nonLeafNodes / finalSteps
+    const dedupRatio = finalSteps > 0 ? nonLeafNodes / finalSteps : 0
     console.log(
         `\n  Deduplication ratio: ${dedupRatio.toFixed(1)}x (${nonLeafNodes.toLocaleString()} non-leaf nodes -> ${finalSteps.toLocaleString()} unique ReactionSteps)`
     )

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -9,6 +9,10 @@ const globalForPrisma = global as unknown as {
     prisma: PrismaClient
 }
 
+if (!process.env.DATABASE_URL) {
+    throw new Error('DATABASE_URL environment variable is not set')
+}
+
 const adapter = new PrismaBetterSqlite3({
     url: process.env.DATABASE_URL,
 })

--- a/src/lib/services/data/prediction.data.ts
+++ b/src/lib/services/data/prediction.data.ts
@@ -69,7 +69,7 @@ async function _findPredictedRouteNodes(targetId: string, runId: string, rank: n
         select: {
             route: {
                 select: {
-                    nodes: { include: { molecule: true } },
+                    nodes: { include: { molecule: true, reactionStep: true } },
                 },
             },
         },

--- a/src/lib/services/data/route.data.ts
+++ b/src/lib/services/data/route.data.ts
@@ -16,7 +16,7 @@ import prisma from '@/lib/db'
 async function _findNodesForRoute(routeId: string) {
     return prisma.routeNode.findMany({
         where: { routeId },
-        include: { molecule: true },
+        include: { molecule: true, reactionStep: true },
     })
 }
 export const findNodesForRoute = cache(_findNodesForRoute, ['nodes-for-route'], {
@@ -31,7 +31,7 @@ async function _findPredictedRouteForTarget(targetId: string, runId: string, ran
         include: {
             route: {
                 include: {
-                    nodes: { include: { molecule: true } },
+                    nodes: { include: { molecule: true, reactionStep: true } },
                 },
             },
         },

--- a/src/lib/services/loaders/benchmark-loader.service.ts
+++ b/src/lib/services/loaders/benchmark-loader.service.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto'
 import * as fs from 'fs'
 import * as zlib from 'zlib'
 import { Prisma } from '@prisma/client'
@@ -91,7 +92,20 @@ async function parseBenchmarkFile(filePath: string): Promise<PythonBenchmarkSet>
 }
 
 /**
+ * Computes reaction hash for a synthesis step using InChIKeys.
+ * Used to detect and deduplicate identical reactions across routes.
+ * Aligns with Python retrocast's ReactionSignature convention.
+ */
+function computeReactionHash(step: PythonReactionStep, productInchikey: string): string {
+    const reactantInchikeys = step.reactants.map((r) => r.inchikey).sort()
+    const content = `${productInchikey}>>${reactantInchikeys.join('.')}`
+    return crypto.createHash('sha256').update(content).digest('hex')
+}
+
+/**
  * Internal structure for building route nodes in memory before bulk insert.
+ * Reaction data (reactionHash, template, metadata) is stored temporarily here
+ * for ReactionStep upsert, then only the reactionStepId is written to RouteNode.
  */
 interface RouteNodeToCreate {
     tempId: string // Temporary ID for tracking parent-child relationships
@@ -99,8 +113,9 @@ interface RouteNodeToCreate {
     moleculeInchikey: string
     parentTempId: string | null
     isLeaf: boolean
-    template: string | null
-    metadata: string | null
+    reactionHash: string | null // Used for ReactionStep dedup, not stored on RouteNode
+    template: string | null // Stored on ReactionStep, not RouteNode
+    metadata: string | null // Stored on ReactionStep, not RouteNode
     smiles: string
 }
 
@@ -135,12 +150,16 @@ function collectRouteTreeData(
 
     // Create node data
     const isLeaf = !molecule.synthesis_step
+    const reactionHash = molecule.synthesis_step
+        ? computeReactionHash(molecule.synthesis_step, molecule.inchikey)
+        : null
     const node: RouteNodeToCreate = {
         tempId,
         routeId,
         moleculeInchikey: molecule.inchikey,
         parentTempId,
         isLeaf,
+        reactionHash,
         template: molecule.synthesis_step?.template || null,
         metadata: molecule.synthesis_step?.metadata ? JSON.stringify(molecule.synthesis_step.metadata) : null,
         smiles: molecule.smiles,
@@ -212,12 +231,43 @@ async function storeRouteTree(
         }
     }
 
-    // Step 3: Create all nodes with proper parent-child relationships
-    // First pass: create all nodes and build a map of tempId to real ID
+    // Step 3: Upsert ReactionStep records for non-leaf nodes
+    const reactionHashToData = new Map<string, { template: string | null; metadata: string | null }>()
+    for (const node of nodesData) {
+        if (node.reactionHash && !reactionHashToData.has(node.reactionHash)) {
+            reactionHashToData.set(node.reactionHash, {
+                template: node.template,
+                metadata: node.metadata,
+            })
+        }
+    }
+
+    const reactionHashes = Array.from(reactionHashToData.keys())
+    const reactionHashToId = new Map<string, string>()
+
+    if (reactionHashes.length > 0) {
+        const existingSteps = await tx.reactionStep.findMany({
+            where: { reactionHash: { in: reactionHashes } },
+            select: { id: true, reactionHash: true },
+        })
+        for (const step of existingSteps) {
+            reactionHashToId.set(step.reactionHash, step.id)
+        }
+
+        for (const [hash, data] of reactionHashToData) {
+            if (!reactionHashToId.has(hash)) {
+                const created = await tx.reactionStep.create({
+                    data: { reactionHash: hash, template: data.template, metadata: data.metadata },
+                    select: { id: true },
+                })
+                reactionHashToId.set(hash, created.id)
+            }
+        }
+    }
+
+    // Step 4: Create all nodes with proper parent-child relationships
     const tempIdToRealId = new Map<string, string>()
 
-    // We need to create nodes in order (parent before children)
-    // Build a tree structure to ensure proper ordering
     const nodesByParent = new Map<string | null, RouteNodeToCreate[]>()
     for (const node of nodesData) {
         const parentKey = node.parentTempId
@@ -241,6 +291,7 @@ async function storeRouteTree(
             }
 
             const parentId = nodeData.parentTempId ? tempIdToRealId.get(nodeData.parentTempId) || null : null
+            const reactionStepId = nodeData.reactionHash ? (reactionHashToId.get(nodeData.reactionHash) ?? null) : null
 
             const createdNode = await tx.routeNode.create({
                 data: {
@@ -248,8 +299,7 @@ async function storeRouteTree(
                     moleculeId,
                     parentId,
                     isLeaf: nodeData.isLeaf,
-                    template: nodeData.template,
-                    metadata: nodeData.metadata,
+                    reactionStepId,
                 },
                 select: { id: true },
             })

--- a/src/lib/services/loaders/benchmark-loader.service.ts
+++ b/src/lib/services/loaders/benchmark-loader.service.ts
@@ -5,6 +5,7 @@ import { Prisma } from '@prisma/client'
 
 import type { LoadBenchmarkResult } from '@/types'
 import prisma from '@/lib/db'
+import { upsertReactionSteps } from '@/lib/services/loaders/reaction-step.helpers'
 
 // ============================================================================
 // Types for internal use (from Python retrocast models)
@@ -153,6 +154,21 @@ function collectRouteTreeData(
     const reactionHash = molecule.synthesis_step
         ? computeReactionHash(molecule.synthesis_step, molecule.inchikey)
         : null
+
+    // Prepare node metadata (reagents, solvents, mapped_smiles)
+    // Aligned with prediction-loader to ensure consistent ReactionStep.metadata format
+    let metadata: string | null = null
+    if (molecule.synthesis_step) {
+        const metadataObj: Record<string, unknown> = {}
+        if (molecule.synthesis_step.reagents) metadataObj.reagents = molecule.synthesis_step.reagents
+        if (molecule.synthesis_step.solvents) metadataObj.solvents = molecule.synthesis_step.solvents
+        if (molecule.synthesis_step.mapped_smiles) metadataObj.mapped_smiles = molecule.synthesis_step.mapped_smiles
+        if (molecule.synthesis_step.metadata) metadataObj.python_metadata = molecule.synthesis_step.metadata
+        if (Object.keys(metadataObj).length > 0) {
+            metadata = JSON.stringify(metadataObj)
+        }
+    }
+
     const node: RouteNodeToCreate = {
         tempId,
         routeId,
@@ -161,7 +177,7 @@ function collectRouteTreeData(
         isLeaf,
         reactionHash,
         template: molecule.synthesis_step?.template || null,
-        metadata: molecule.synthesis_step?.metadata ? JSON.stringify(molecule.synthesis_step.metadata) : null,
+        metadata,
         smiles: molecule.smiles,
     }
     nodes.push(node)
@@ -232,38 +248,7 @@ async function storeRouteTree(
     }
 
     // Step 3: Upsert ReactionStep records for non-leaf nodes
-    const reactionHashToData = new Map<string, { template: string | null; metadata: string | null }>()
-    for (const node of nodesData) {
-        if (node.reactionHash && !reactionHashToData.has(node.reactionHash)) {
-            reactionHashToData.set(node.reactionHash, {
-                template: node.template,
-                metadata: node.metadata,
-            })
-        }
-    }
-
-    const reactionHashes = Array.from(reactionHashToData.keys())
-    const reactionHashToId = new Map<string, string>()
-
-    if (reactionHashes.length > 0) {
-        const existingSteps = await tx.reactionStep.findMany({
-            where: { reactionHash: { in: reactionHashes } },
-            select: { id: true, reactionHash: true },
-        })
-        for (const step of existingSteps) {
-            reactionHashToId.set(step.reactionHash, step.id)
-        }
-
-        for (const [hash, data] of reactionHashToData) {
-            if (!reactionHashToId.has(hash)) {
-                const created = await tx.reactionStep.create({
-                    data: { reactionHash: hash, template: data.template, metadata: data.metadata },
-                    select: { id: true },
-                })
-                reactionHashToId.set(hash, created.id)
-            }
-        }
-    }
+    const reactionHashToId = await upsertReactionSteps(nodesData, tx)
 
     // Step 4: Create all nodes with proper parent-child relationships
     const tempIdToRealId = new Map<string, string>()

--- a/src/lib/services/loaders/prediction-loader.service.ts
+++ b/src/lib/services/loaders/prediction-loader.service.ts
@@ -105,12 +105,13 @@ export function isRouteConvergent(root: PythonMolecule): boolean {
 }
 
 /**
- * Computes reaction hash for a synthesis step.
- * Used to detect duplicate reactions across routes.
+ * Computes reaction hash for a synthesis step using InChIKeys.
+ * Used to detect and deduplicate identical reactions across routes.
+ * Aligns with Python retrocast's ReactionSignature convention.
  */
-function computeReactionHash(step: PythonReactionStep, productSmiles: string): string {
-    const reactantSmiles = step.reactants.map((r) => r.smiles).sort()
-    const content = `${productSmiles}>>${reactantSmiles.join('.')}`
+function computeReactionHash(step: PythonReactionStep, productInchikey: string): string {
+    const reactantInchikeys = step.reactants.map((r) => r.inchikey).sort()
+    const content = `${productInchikey}>>${reactantInchikeys.join('.')}`
     return crypto.createHash('sha256').update(content).digest('hex')
 }
 
@@ -284,6 +285,8 @@ export async function createMoleculeFromPython(pythonMolecule: PythonMolecule): 
 
 /**
  * Internal structure for building route nodes in memory before bulk insert.
+ * Reaction data (reactionHash, template, metadata) is stored temporarily here
+ * for ReactionStep upsert, then only the reactionStepId is written to RouteNode.
  */
 interface RouteNodeToCreate {
     tempId: string // Temporary ID for tracking parent-child relationships
@@ -291,9 +294,9 @@ interface RouteNodeToCreate {
     moleculeInchikey: string
     parentTempId: string | null
     isLeaf: boolean
-    reactionHash: string | null
-    template: string | null
-    metadata: string | null
+    reactionHash: string | null // Used for ReactionStep dedup, not stored on RouteNode
+    template: string | null // Stored on ReactionStep, not RouteNode
+    metadata: string | null // Stored on ReactionStep, not RouteNode
 }
 
 /**
@@ -330,10 +333,10 @@ function collectRouteTreeData(
     // Determine if this is a leaf node
     const isLeaf = !pythonMol.synthesis_step || pythonMol.is_leaf === true
 
-    // Compute reaction hash if not a leaf
+    // Compute reaction hash if not a leaf (uses InChIKeys for canonical identity)
     let reactionHash: string | null = null
     if (pythonMol.synthesis_step) {
-        reactionHash = computeReactionHash(pythonMol.synthesis_step, pythonMol.smiles)
+        reactionHash = computeReactionHash(pythonMol.synthesis_step, pythonMol.inchikey)
     }
 
     // Prepare node metadata (reagents, solvents, mapped_smiles)
@@ -425,7 +428,44 @@ async function storeRouteTree(
         }
     }
 
-    // Step 3: Create all nodes with proper parent-child relationships
+    // Step 3: Upsert ReactionStep records for non-leaf nodes
+    // Collect unique reactions by reactionHash
+    const reactionHashToData = new Map<string, { template: string | null; metadata: string | null }>()
+    for (const node of nodesData) {
+        if (node.reactionHash && !reactionHashToData.has(node.reactionHash)) {
+            reactionHashToData.set(node.reactionHash, {
+                template: node.template,
+                metadata: node.metadata,
+            })
+        }
+    }
+
+    // Find existing ReactionStep records
+    const reactionHashes = Array.from(reactionHashToData.keys())
+    const reactionHashToId = new Map<string, string>()
+
+    if (reactionHashes.length > 0) {
+        const existingSteps = await db.reactionStep.findMany({
+            where: { reactionHash: { in: reactionHashes } },
+            select: { id: true, reactionHash: true },
+        })
+        for (const step of existingSteps) {
+            reactionHashToId.set(step.reactionHash, step.id)
+        }
+
+        // Create missing ReactionStep records
+        for (const [hash, data] of reactionHashToData) {
+            if (!reactionHashToId.has(hash)) {
+                const created = await db.reactionStep.create({
+                    data: { reactionHash: hash, template: data.template, metadata: data.metadata },
+                    select: { id: true },
+                })
+                reactionHashToId.set(hash, created.id)
+            }
+        }
+    }
+
+    // Step 4: Create all nodes with proper parent-child relationships
     // Build node map by parent to enable breadth-first creation
     const tempIdToRealId = new Map<string, string>()
     const nodesByParent = new Map<string | null, RouteNodeToCreate[]>()
@@ -455,6 +495,7 @@ async function storeRouteTree(
             }
 
             const parentId = nodeData.parentTempId ? tempIdToRealId.get(nodeData.parentTempId) || null : null
+            const reactionStepId = nodeData.reactionHash ? (reactionHashToId.get(nodeData.reactionHash) ?? null) : null
 
             const createdNode = await db.routeNode.create({
                 data: {
@@ -462,9 +503,7 @@ async function storeRouteTree(
                     moleculeId,
                     parentId,
                     isLeaf: nodeData.isLeaf,
-                    reactionHash: nodeData.reactionHash,
-                    template: nodeData.template,
-                    metadata: nodeData.metadata,
+                    reactionStepId,
                 },
                 select: { id: true },
             })

--- a/src/lib/services/loaders/prediction-loader.service.ts
+++ b/src/lib/services/loaders/prediction-loader.service.ts
@@ -3,6 +3,7 @@ import { Prisma, ReliabilityCode } from '@prisma/client'
 
 import type { MetricResult, ModelStatistics, ReliabilityFlag, StratifiedMetric } from '@/types'
 import prisma from '@/lib/db'
+import { upsertReactionSteps } from '@/lib/services/loaders/reaction-step.helpers'
 
 // Convenience alias so internal helpers can accept either the real client or a tx client.
 type DbClient = typeof prisma | Prisma.TransactionClient
@@ -429,41 +430,7 @@ async function storeRouteTree(
     }
 
     // Step 3: Upsert ReactionStep records for non-leaf nodes
-    // Collect unique reactions by reactionHash
-    const reactionHashToData = new Map<string, { template: string | null; metadata: string | null }>()
-    for (const node of nodesData) {
-        if (node.reactionHash && !reactionHashToData.has(node.reactionHash)) {
-            reactionHashToData.set(node.reactionHash, {
-                template: node.template,
-                metadata: node.metadata,
-            })
-        }
-    }
-
-    // Find existing ReactionStep records
-    const reactionHashes = Array.from(reactionHashToData.keys())
-    const reactionHashToId = new Map<string, string>()
-
-    if (reactionHashes.length > 0) {
-        const existingSteps = await db.reactionStep.findMany({
-            where: { reactionHash: { in: reactionHashes } },
-            select: { id: true, reactionHash: true },
-        })
-        for (const step of existingSteps) {
-            reactionHashToId.set(step.reactionHash, step.id)
-        }
-
-        // Create missing ReactionStep records
-        for (const [hash, data] of reactionHashToData) {
-            if (!reactionHashToId.has(hash)) {
-                const created = await db.reactionStep.create({
-                    data: { reactionHash: hash, template: data.template, metadata: data.metadata },
-                    select: { id: true },
-                })
-                reactionHashToId.set(hash, created.id)
-            }
-        }
-    }
+    const reactionHashToId = await upsertReactionSteps(nodesData, db)
 
     // Step 4: Create all nodes with proper parent-child relationships
     // Build node map by parent to enable breadth-first creation

--- a/src/lib/services/loaders/reaction-step.helpers.ts
+++ b/src/lib/services/loaders/reaction-step.helpers.ts
@@ -1,0 +1,63 @@
+/**
+ * Shared helper for upserting ReactionStep records during route loading.
+ * Used by both the prediction loader and benchmark loader.
+ */
+import type { Prisma } from '@prisma/client'
+
+import type prisma from '@/lib/db'
+
+/** Minimal DB client interface — works with both PrismaClient and TransactionClient. */
+type DbClient = typeof prisma | Prisma.TransactionClient
+
+/** Shape of a node that carries reaction data for ReactionStep upsert. */
+interface NodeWithReactionData {
+    reactionHash: string | null
+    template: string | null
+    metadata: string | null
+}
+
+/**
+ * Upserts ReactionStep records for a batch of route nodes.
+ * Finds existing steps by reactionHash and creates missing ones.
+ *
+ * @returns Map from reactionHash to ReactionStep.id
+ */
+export async function upsertReactionSteps(nodes: NodeWithReactionData[], db: DbClient): Promise<Map<string, string>> {
+    // Collect unique reactions by reactionHash
+    const reactionHashToData = new Map<string, { template: string | null; metadata: string | null }>()
+    for (const node of nodes) {
+        if (node.reactionHash && !reactionHashToData.has(node.reactionHash)) {
+            reactionHashToData.set(node.reactionHash, {
+                template: node.template,
+                metadata: node.metadata,
+            })
+        }
+    }
+
+    const reactionHashToId = new Map<string, string>()
+    const reactionHashes = Array.from(reactionHashToData.keys())
+
+    if (reactionHashes.length === 0) return reactionHashToId
+
+    // Find existing ReactionStep records
+    const existingSteps = await db.reactionStep.findMany({
+        where: { reactionHash: { in: reactionHashes } },
+        select: { id: true, reactionHash: true },
+    })
+    for (const step of existingSteps) {
+        reactionHashToId.set(step.reactionHash, step.id)
+    }
+
+    // Create missing ReactionStep records
+    for (const [hash, data] of reactionHashToData) {
+        if (!reactionHashToId.has(hash)) {
+            const created = await db.reactionStep.create({
+                data: { reactionHash: hash, template: data.template, metadata: data.metadata },
+                select: { id: true },
+            })
+            reactionHashToId.set(hash, created.id)
+        }
+    }
+
+    return reactionHashToId
+}

--- a/src/lib/tree-builder/route-tree.ts
+++ b/src/lib/tree-builder/route-tree.ts
@@ -29,6 +29,7 @@ export function buildRouteTree(nodes: RouteNodeWithMoleculePayload): RouteNodeWi
     nodes.forEach((node) => {
         nodeMap.set(node.id, {
             ...node,
+            reactionStep: node.reactionStep ?? null,
             children: [],
         })
     })

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -252,25 +252,36 @@ export interface RouteSummary {
 }
 
 /**
+ * Shared, deduplicated reaction step data.
+ * Mirrors retrocast.models.chem.ReactionStep from the Python library.
+ */
+export interface ReactionStep {
+    id: string
+    reactionHash: string
+    template: string | null
+    metadata: string | null // JSON: reagents, solvents, mapped_smiles
+}
+
+/**
  * Represents a node in the route tree.
- * Each node is either a leaf (starting material) or has a synthesis step.
+ * Each node is either a leaf (starting material) or has a synthesis step
+ * stored in a shared ReactionStep record.
  */
 export interface RouteNode {
     id: string
     routeId: string
     moleculeId: string
     parentId: string | null
+    reactionStepId: string | null
     isLeaf: boolean
-    reactionHash: string | null
-    template: string | null
-    metadata: string | null // JSON: reagents, solvents, mapped_smiles
 }
 
 /**
- * Extended route node with molecule and children for tree traversal.
+ * Extended route node with molecule, reaction step, and children for tree traversal.
  */
 export interface RouteNodeWithDetails extends RouteNode {
     molecule: Molecule
+    reactionStep: ReactionStep | null
     children: RouteNodeWithDetails[]
 }
 

--- a/tests/helpers/factories.ts
+++ b/tests/helpers/factories.ts
@@ -231,9 +231,8 @@ export function pythonMoleculeToFlatNodes(
         moleculeId: `mol-${mol.inchikey.slice(0, 8)}`,
         parentId,
         isLeaf,
-        reactionHash: null,
-        template: null,
-        metadata: null,
+        reactionStepId: null,
+        reactionStep: null,
         molecule: {
             id: `mol-${mol.inchikey.slice(0, 8)}`,
             inchikey: mol.inchikey,

--- a/tests/lib/tree-builder/route-tree.test.ts
+++ b/tests/lib/tree-builder/route-tree.test.ts
@@ -188,9 +188,8 @@ describe('buildRouteTree', () => {
                     moleculeId: 'mol-1',
                     parentId: null,
                     isLeaf: false,
-                    reactionHash: null,
-                    template: null,
-                    metadata: null,
+                    reactionStepId: null,
+                    reactionStep: null,
                     molecule: { id: 'mol-1', inchikey: 'ROOT-INCHIKEY-00001-N', smiles: 'CC' },
                 },
                 {
@@ -199,9 +198,8 @@ describe('buildRouteTree', () => {
                     moleculeId: 'mol-2',
                     parentId: 'root-1',
                     isLeaf: true,
-                    reactionHash: null,
-                    template: null,
-                    metadata: null,
+                    reactionStepId: null,
+                    reactionStep: null,
                     molecule: { id: 'mol-2', inchikey: 'LEAF-INCHIKEY-00001-N', smiles: 'C' },
                 },
             ]
@@ -224,9 +222,8 @@ describe('buildRouteTree', () => {
                     moleculeId: 'mol-a',
                     parentId: null,
                     isLeaf: true,
-                    reactionHash: null,
-                    template: null,
-                    metadata: null,
+                    reactionStepId: null,
+                    reactionStep: null,
                     molecule: { id: 'mol-a', inchikey: 'ROOTA-INCHIKEY-0001-N', smiles: 'C' },
                 },
                 {
@@ -235,9 +232,8 @@ describe('buildRouteTree', () => {
                     moleculeId: 'mol-b',
                     parentId: null, // second "root" — orphaned under current implementation
                     isLeaf: true,
-                    reactionHash: null,
-                    template: null,
-                    metadata: null,
+                    reactionStepId: null,
+                    reactionStep: null,
                     molecule: { id: 'mol-b', inchikey: 'ROOTB-INCHIKEY-0001-N', smiles: 'CC' },
                 },
             ]
@@ -259,9 +255,8 @@ describe('buildRouteTree', () => {
                     moleculeId: 'mol-r',
                     parentId: null,
                     isLeaf: false,
-                    reactionHash: null,
-                    template: null,
-                    metadata: null,
+                    reactionStepId: null,
+                    reactionStep: null,
                     molecule: { id: 'mol-r', inchikey: 'ROOTR-INCHIKEY-0001-N', smiles: 'CCC' },
                 },
                 {
@@ -270,9 +265,8 @@ describe('buildRouteTree', () => {
                     moleculeId: 'mol-o',
                     parentId: 'does-not-exist', // dangling parent reference
                     isLeaf: true,
-                    reactionHash: null,
-                    template: null,
-                    metadata: null,
+                    reactionStepId: null,
+                    reactionStep: null,
                     molecule: { id: 'mol-o', inchikey: 'ORPHN-INCHIKEY-0001-N', smiles: 'C' },
                 },
             ]


### PR DESCRIPTION
## Summary

- Introduce a shared `ReactionStep` table to deduplicate reaction data (template, metadata, reactionHash) across routes, mirroring Python retrocast's `ReactionStep` model
- `RouteNode` becomes a thin topology-only record pointing to a shared `ReactionStep` via `reactionStepId` FK — reaction data is no longer duplicated per-route
- Switch `computeReactionHash` from SMILES-based to InChIKey-based, aligning with Python's `ReactionSignature` convention
- Benchmark loader gains `reactionHash` computation (was previously missing entirely)

## Impact

| Metric | Before | After |
|--------|--------|-------|
| Database size | 2.2 GB | 1.5 GB (**-32%**) |
| Non-leaf RouteNode rows | 1,503,692 | 1,503,692 (same count, much smaller per row) |
| Unique ReactionStep records | N/A | 272,094 (**5.5x dedup ratio**) |
| `template`/`metadata` copies | 1,503,692 | 272,094 |

## Changes

**Schema:**
- New `ReactionStep` model: `id`, `reactionHash` (unique), `template`, `metadata`
- `RouteNode`: dropped `reactionHash`, `template`, `metadata` columns; added `reactionStepId` FK
- Two Prisma migrations + a data migration script (`scripts/migrate-reaction-steps.ts`)

**Write path (loaders):**
- Both loaders upsert `ReactionStep` records before creating `RouteNode`
- `computeReactionHash` uses InChIKeys instead of SMILES

**Read path:**
- Data layer queries add `include: { reactionStep: true }` to node fetches
- Tree builder propagates `reactionStep` through node spread
- No UI changes needed (visualization only uses molecule smiles/inchikey)

**Tests:**
- All 288 tests pass, 0 lint errors, 0 new type errors
- Updated test factories and fixtures for new schema shape

## Migration

The data migration script runs in ~26 seconds on the current 3M-row database. It:
1. Recomputes all reaction hashes using InChIKeys
2. Extracts unique reactions into `ReactionStep` records  
3. Links all non-leaf `RouteNode` records to their `ReactionStep`

A database backup is created at `prisma/dev.db.backup-before-reaction-step` before migration. Run `VACUUM` after migration to reclaim space from dropped columns.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Introduces a shared `ReactionStep` table to deduplicate reaction data across routes, achieving a 32% reduction in database size (2.2 GB → 1.5 GB) with a 5.5x deduplication ratio. The `RouteNode` model becomes topology-only, referencing a shared `ReactionStep` via FK. The `computeReactionHash` function is switched from SMILES-based to InChIKey-based to align with Python retrocast's `ReactionSignature` convention.

- **Schema**: New `ReactionStep` model with unique `reactionHash`; `RouteNode` drops inline `reactionHash`/`template`/`metadata` in favor of `reactionStepId` FK
- **Write path**: Both loaders upsert `ReactionStep` records before creating `RouteNode`, using a find-then-create pattern within transactions
- **Read path**: Data layer queries add `include: { reactionStep: true }` and tree builder propagates the relation
- **Migration**: Data migration script uses raw `better-sqlite3` for performance on ~3M rows; runs between the two Prisma migrations. Note: the script is missing the backup step promised in the PR description and disables `foreign_keys` without re-enabling for verification
- **Tests**: All fixtures updated to match new schema shape; test coverage appears comprehensive

<h3>Confidence Score: 4/5</h3>

- This PR is well-structured and safe for the application code; the migration script has minor issues that should be addressed before running on production data.
- The application code changes (loaders, data layer, types, tree builder, tests) are clean and well-tested with 288 passing tests. The schema design is sound with proper indexing and FK relationships. The migration script has two issues: missing backup creation and disabled FK validation during verification. These are important for data safety but don't affect the application runtime.
- `scripts/migrate-reaction-steps.ts` needs attention for the missing backup step and FK re-enable before verification.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| prisma/schema.prisma | New `ReactionStep` model added with proper unique index on `reactionHash`, FK from `RouteNode`, and appropriate indexing. Schema change is clean and well-structured. |
| scripts/migrate-reaction-steps.ts | Data migration script with `foreign_keys = OFF` never re-enabled, missing the backup step mentioned in PR description, and a potential division-by-zero in verification. |
| src/lib/services/loaders/benchmark-loader.service.ts | Adds `computeReactionHash` and ReactionStep upsert logic. Metadata handling differs from prediction loader (uses raw `metadata` field vs. structured reagents/solvents object). |
| src/lib/services/loaders/prediction-loader.service.ts | Switches `computeReactionHash` from SMILES to InChIKey-based. Adds ReactionStep upsert with first-writer-wins dedup. Transaction context is correctly propagated. |
| src/lib/services/data/route.data.ts | Adds `reactionStep: true` to `include` for both `findNodesForRoute` and `findPredictedRouteForTarget`. Clean, correct changes. |
| src/lib/tree-builder/route-tree.ts | Propagates `reactionStep` through the tree node spread with a null-safe fallback. Single-line addition, correct. |
| src/types/index.ts | Adds `ReactionStep` interface, updates `RouteNode` to replace inline fields with `reactionStepId` FK, and extends `RouteNodeWithDetails` with `reactionStep` relation. |
| tests/helpers/factories.ts | Updates `pythonMoleculeToFlatNodes` to use `reactionStepId: null` and `reactionStep: null` instead of the old inline fields. Correct alignment with new schema. |

</details>

<h3>Entity Relationship Diagram</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
erDiagram
    Route ||--o{ RouteNode : "has nodes"
    ReactionStep ||--o{ RouteNode : "shared by"
    Molecule ||--o{ RouteNode : "represents"
    RouteNode ||--o{ RouteNode : "parent-child"

    ReactionStep {
        string id PK
        string reactionHash UK "SHA256(product>>reactants)"
        string template "SMARTS pattern"
        string metadata "JSON: reagents, solvents"
    }

    RouteNode {
        string id PK
        string routeId FK
        string moleculeId FK
        string parentId FK "nullable, tree structure"
        string reactionStepId FK "nullable, null for leaves"
        boolean isLeaf
    }

    Route {
        string id PK
        string signature UK
        string contentHash UK
        int length
        boolean isConvergent
    }
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: scripts/migrate-reaction-steps.ts
Line: 47-53

Comment:
**Missing backup and FK re-enable**

The PR description promises a database backup at `prisma/dev.db.backup-before-reaction-step`, but the script itself never creates one. Additionally, `foreign_keys = OFF` is set at line 53 but never re-enabled before `db.close()`. While the pragma is per-connection and won't persist, it means the verification step (Step 4) runs without FK enforcement — so invalid `reactionStepId` references would not be caught.

Consider:
1. Adding `fs.copyFileSync(DB_PATH, DB_PATH + '.backup-before-reaction-step')` before the migration begins.
2. Re-enabling `foreign_keys` before verification:
```suggestion
    const db = new Database(DB_PATH)

    // Performance pragmas
    db.pragma('journal_mode = WAL')
    db.pragma('synchronous = NORMAL')
    db.pragma('foreign_keys = OFF') // Re-enabled before verification step
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: scripts/migrate-reaction-steps.ts
Line: 373

Comment:
**Division by zero when no reactions exist**

If `finalSteps` is 0 (e.g., a database with only leaf nodes), this produces `Infinity` or `NaN`. This is an edge case but the script is meant to be idempotent and could be run against an empty or leaf-only database.

```suggestion
    const dedupRatio = finalSteps > 0 ? nonLeafNodes / finalSteps : 0
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/lib/services/loaders/benchmark-loader.service.ts
Line: 163-164

Comment:
**Metadata stored differently than prediction loader**

The benchmark loader stores `molecule.synthesis_step.metadata` as-is (the raw Python metadata field), while the prediction loader (`prediction-loader.service.ts:342-353`) constructs a richer object with `reagents`, `solvents`, `mapped_smiles`, and `python_metadata` fields. Since both loaders feed the same `ReactionStep` table with a first-writer-wins strategy, the metadata format stored for a given reaction depends on which loader runs first. 

This is a pre-existing inconsistency in how the two loaders handle metadata, but it becomes more impactful now that the data is shared/deduplicated — the prediction loader's richer metadata could be silently discarded if the benchmark loader populated the `ReactionStep` first (or vice versa). Worth considering whether to align the metadata extraction logic.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 1b8716c</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Introduce `ReactionStep` table for reaction-level deduplication across route nodes
> - Adds a new `ReactionStep` model/table with `id`, `reactionHash` (unique), `template`, and `metadata`, linked to `RouteNode` via a nullable `reactionStepId` foreign key.
> - Moves reaction data off `RouteNode` — the inline `reactionHash`, `template`, and `metadata` columns are dropped in a follow-up migration after backfill.
> - Reaction hashes are now computed from InChIKey-based product/reactant strings (SHA256) instead of SMILES in both the prediction and benchmark loaders.
> - Adds a new [`upsertReactionSteps`](https://github.com/ischemist/syntharena/pull/66/files#diff-beb8ecad55abfc991710b8a26a2b30f279e73fc6f483a6eacda9dddb9d7e509b) helper for idempotent upsert of `ReactionStep` records, used by both loaders before `RouteNode` creation.
> - Adds a standalone [`migrate-reaction-steps.ts`](https://github.com/ischemist/syntharena/pull/66/files#diff-4fb9c65b4f5c59e2edeb242ebe95ba28ec62d09bd3d40661d02038c0609ce1da) CLI script to backfill existing data with backup and verification steps.
> - Risk: the second migration drops `reactionHash`/`template`/`metadata` from `RouteNode` and includes a guard that blocks the migration if any unbackfilled rows remain.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fc1d1d7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->