### PR TITLE
REF: remove route content hash from syntharena

### DIFF
--- a/prisma/migrations/20260421170000_remove_route_content_hash/migration.sql
+++ b/prisma/migrations/20260421170000_remove_route_content_hash/migration.sql
@@ -1,0 +1,45 @@
+-- Remove Route.contentHash now that SynthArena treats route identity as topology-only.
+-- Also add the missing foreign key for RouteNode.reactionStepId while rebuilding the table.
+
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+
+CREATE TABLE "new_Route" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "signature" TEXT NOT NULL,
+    "length" INTEGER NOT NULL,
+    "isConvergent" BOOLEAN NOT NULL
+);
+
+INSERT INTO "new_Route" ("id", "isConvergent", "length", "signature")
+SELECT "id", "isConvergent", "length", "signature"
+FROM "Route";
+
+DROP TABLE "Route";
+ALTER TABLE "new_Route" RENAME TO "Route";
+CREATE UNIQUE INDEX "Route_signature_key" ON "Route"("signature");
+
+CREATE TABLE "new_RouteNode" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "routeId" TEXT NOT NULL,
+    "moleculeId" TEXT NOT NULL,
+    "parentId" TEXT,
+    "reactionStepId" TEXT,
+    "isLeaf" BOOLEAN NOT NULL DEFAULT false,
+    CONSTRAINT "RouteNode_routeId_fkey" FOREIGN KEY ("routeId") REFERENCES "Route" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "RouteNode_moleculeId_fkey" FOREIGN KEY ("moleculeId") REFERENCES "Molecule" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "RouteNode_reactionStepId_fkey" FOREIGN KEY ("reactionStepId") REFERENCES "ReactionStep" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "RouteNode_parentId_fkey" FOREIGN KEY ("parentId") REFERENCES "RouteNode" ("id") ON DELETE SET NULL ON UPDATE NO ACTION
+);
+
+INSERT INTO "new_RouteNode" ("id", "isLeaf", "moleculeId", "parentId", "reactionStepId", "routeId")
+SELECT "id", "isLeaf", "moleculeId", "parentId", "reactionStepId", "routeId"
+FROM "RouteNode";
+
+DROP TABLE "RouteNode";
+ALTER TABLE "new_RouteNode" RENAME TO "RouteNode";
+CREATE INDEX "RouteNode_routeId_idx" ON "RouteNode"("routeId");
+CREATE INDEX "RouteNode_reactionStepId_idx" ON "RouteNode"("reactionStepId");
+
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -198,9 +198,8 @@ model PredictionRun {
 model Route {
   id String @id @default(cuid())
 
-  // Core Route Properties (Topology-level, unique)
-  signature   String @unique // SHA256 from get_signature() (topology only) - NOW REQUIRED & UNIQUE
-  contentHash String @unique // SHA256 from get_content_hash() - NOW UNIQUE
+  // Core route identity for visualization and benchmark deduplication.
+  signature String @unique // SHA256 from get_signature() (topology only)
 
   // Cached Computations (for fast filtering)
   length       Int
@@ -237,13 +236,12 @@ model PredictionRoute {
   @@index([routeId])
 }
 
-// Shared, deduplicated reaction step data.
-// Mirrors retrocast.models.chem.ReactionStep from the Python library.
-// Multiple RouteNodes across different routes can reference the same ReactionStep
-// when they represent the identical reaction (same product + reactants by InChIKey).
+// Shared reaction-step data used for route visualization-level deduplication.
+// This stores reaction topology plus one representative template/metadata payload,
+// not a full planner-specific reaction provenance record.
 model ReactionStep {
-  id           String @id @default(cuid())
-  reactionHash String @unique // SHA256 of "productInchikey>>reactant1Inchikey.reactant2Inchikey" (sorted)
+  id           String  @id @default(cuid())
+  reactionHash String  @unique // SHA256 of "productInchikey>>reactant1Inchikey.reactant2Inchikey" (sorted)
   template     String? // Reaction template (e.g., SMARTS pattern)
   metadata     String? // JSON: reagents, solvents, mapped_smiles
 
@@ -251,11 +249,11 @@ model ReactionStep {
 }
 
 model RouteNode {
-  id              String  @id @default(cuid())
-  routeId         String
-  moleculeId      String
-  parentId        String? // Tree structure
-  reactionStepId  String? // null for leaf nodes
+  id             String  @id @default(cuid())
+  routeId        String
+  moleculeId     String
+  parentId       String? // Tree structure
+  reactionStepId String? // null for leaf nodes
 
   isLeaf Boolean @default(false)
 

--- a/scripts/migrate-reaction-steps.ts
+++ b/scripts/migrate-reaction-steps.ts
@@ -13,6 +13,7 @@
  *
  * Usage:
  *   pnpm tsx scripts/migrate-reaction-steps.ts
+ *   DB_PATH=prisma/prod.db pnpm tsx scripts/migrate-reaction-steps.ts
  */
 import crypto from 'node:crypto'
 import fs from 'node:fs'
@@ -23,7 +24,7 @@ import Database from 'better-sqlite3'
 // Config
 // ---------------------------------------------------------------------------
 
-const DB_PATH = 'prisma/dev.db'
+const DB_PATH = process.env.DB_PATH ?? 'prisma/dev.db'
 const BATCH_SIZE = 50_000
 
 // ---------------------------------------------------------------------------

--- a/src/app/benchmarks/[benchmarkId]/targets/[targetId]/_components/server/target-header.tsx
+++ b/src/app/benchmarks/[benchmarkId]/targets/[targetId]/_components/server/target-header.tsx
@@ -16,7 +16,7 @@ interface TargetHeaderProps {
  * Server component that fetches and displays target header information.
  * Shows the target molecule structure prominently with metadata in a 2-column layout.
  * Left column: molecule structure with smile drawer
- * Right column: target ID, badges, SMILES, InChiKey, and route hashes
+ * Right column: target ID, badges, SMILES, InChiKey, and the primary route signature
  * Handles 404 if target not found.
  */
 export async function TargetHeader({ targetId }: TargetHeaderProps) {
@@ -27,10 +27,10 @@ export async function TargetHeader({ targetId }: TargetHeaderProps) {
         notFound()
     }
 
-    // Fetch acceptable routes to get hash/signature of primary route
+    // Fetch acceptable routes to get the topology signature of the primary route.
     let acceptableRoutes: Array<{
         routeIndex: number
-        route: { id: string; contentHash: string | null; signature: string | null }
+        route: { id: string; signature: string }
     }> = []
     try {
         const routes = await routeView.getAcceptableRoutesForTarget(targetId)
@@ -40,7 +40,7 @@ export async function TargetHeader({ targetId }: TargetHeaderProps) {
         acceptableRoutes = []
     }
 
-    // Get primary route (index 0) for displaying hash/signature
+    // Get primary route (index 0) for displaying the topology signature.
     const primaryRoute = acceptableRoutes.find((ar) => ar.routeIndex === 0)?.route
 
     return (
@@ -90,67 +90,31 @@ export async function TargetHeader({ targetId }: TargetHeaderProps) {
                                 <p className="font-mono text-xs break-all">{target.molecule.inchikey}</p>
                             </div>
 
-                            {/* Route Hashes - only show if primary acceptable route exists and has hash data */}
-                            {primaryRoute && primaryRoute.contentHash && (
-                                <>
-                                    <div>
-                                        <div className="mb-1 flex items-baseline gap-1.5">
-                                            <p className="text-muted-foreground text-xs font-semibold">
-                                                Route Content Hash
-                                            </p>
-                                            <HoverCard>
-                                                <HoverCardTrigger asChild>
-                                                    <button className="text-muted-foreground hover:text-foreground text-xs underline decoration-dotted underline-offset-2 transition-colors">
-                                                        what is this?
-                                                    </button>
-                                                </HoverCardTrigger>
-                                                <HoverCardContent className="w-80">
-                                                    <div className="space-y-2">
-                                                        <h4 className="text-sm font-semibold">Content Hash</h4>
-                                                        <p className="text-xs text-gray-600 dark:text-gray-400">
-                                                            A deterministic SHA-256 hash of the complete route content,
-                                                            including all metadata, reaction details (mapped SMILES,
-                                                            templates, reagents, solvents), rank, and provenance
-                                                            information. Used to verify that two routes are semantically
-                                                            identical in every detail.
-                                                        </p>
-                                                    </div>
-                                                </HoverCardContent>
-                                            </HoverCard>
-                                        </div>
-                                        <p className="font-mono text-xs break-all">{primaryRoute.contentHash}</p>
+                            {primaryRoute && (
+                                <div>
+                                    <div className="mb-1 flex items-baseline gap-1.5">
+                                        <p className="text-muted-foreground text-xs font-semibold">Route Signature</p>
+                                        <HoverCard>
+                                            <HoverCardTrigger asChild>
+                                                <button className="text-muted-foreground hover:text-foreground text-xs underline decoration-dotted underline-offset-2 transition-colors">
+                                                    what is this?
+                                                </button>
+                                            </HoverCardTrigger>
+                                            <HoverCardContent className="w-80">
+                                                <div className="space-y-2">
+                                                    <h4 className="text-sm font-semibold">Route Signature</h4>
+                                                    <p className="text-xs text-gray-600 dark:text-gray-400">
+                                                        A canonical, order-invariant SHA-256 hash of the route topology
+                                                        based only on molecular structures (InChiKeys). Two routes with
+                                                        the same signature have identical synthetic trees, regardless of
+                                                        planner-specific metadata or reaction details.
+                                                    </p>
+                                                </div>
+                                            </HoverCardContent>
+                                        </HoverCard>
                                     </div>
-                                    {primaryRoute.signature && (
-                                        <div>
-                                            <div className="mb-1 flex items-baseline gap-1.5">
-                                                <p className="text-muted-foreground text-xs font-semibold">
-                                                    Route Signature
-                                                </p>
-                                                <HoverCard>
-                                                    <HoverCardTrigger asChild>
-                                                        <button className="text-muted-foreground hover:text-foreground text-xs underline decoration-dotted underline-offset-2 transition-colors">
-                                                            what is this?
-                                                        </button>
-                                                    </HoverCardTrigger>
-                                                    <HoverCardContent className="w-80">
-                                                        <div className="space-y-2">
-                                                            <h4 className="text-sm font-semibold">Route Signature</h4>
-                                                            <p className="text-xs text-gray-600 dark:text-gray-400">
-                                                                A canonical, order-invariant SHA-256 hash of the route
-                                                                topology based only on molecular structures (InChiKeys).
-                                                                Two routes with the same signature have identical
-                                                                synthetic trees, regardless of metadata or reaction
-                                                                details. Perfect for route deduplication and comparing
-                                                                topological equivalence.
-                                                            </p>
-                                                        </div>
-                                                    </HoverCardContent>
-                                                </HoverCard>
-                                            </div>
-                                            <p className="font-mono text-xs break-all">{primaryRoute.signature}</p>
-                                        </div>
-                                    )}
-                                </>
+                                    <p className="font-mono text-xs break-all">{primaryRoute.signature}</p>
+                                </div>
                             )}
                         </div>
                     </div>

--- a/src/lib/services/data/route.data.ts
+++ b/src/lib/services/data/route.data.ts
@@ -48,7 +48,7 @@ async function _findAcceptableRoutesForTarget(targetId: string) {
         select: {
             routeIndex: true,
             route: {
-                select: { id: true, signature: true, contentHash: true },
+                select: { id: true, signature: true },
             },
         },
         orderBy: { routeIndex: 'asc' },

--- a/src/lib/services/loaders/benchmark-loader.service.ts
+++ b/src/lib/services/loaders/benchmark-loader.service.ts
@@ -32,7 +32,6 @@ interface PythonReactionStep {
 interface PythonRoute {
     target: PythonMolecule
     rank: number
-    content_hash?: string
     signature?: string
     length?: number
     has_convergent_reaction?: boolean
@@ -495,13 +494,12 @@ export async function loadBenchmarkFromFile(
                         const routeData = targetData.acceptable_routes[routeIndex]
 
                         // Extract route properties from file
-                        const contentHash = routeData.content_hash || ''
                         const signature = routeData.signature || null
 
-                        // Enforce data quality: acceptable routes must have contentHash and signature for deduplication
-                        if (!contentHash || !signature) {
+                        // Enforce data quality: acceptable routes must have a signature for topology deduplication.
+                        if (!signature) {
                             throw new Error(
-                                `Acceptable route at index ${routeIndex} for target ${externalId} is missing contentHash or signature. Cannot ensure deduplication.`
+                                `Acceptable route at index ${routeIndex} for target ${externalId} is missing a route signature. Cannot ensure deduplication.`
                             )
                         }
 
@@ -511,10 +509,9 @@ export async function loadBenchmarkFromFile(
                         let routeIsConvergentComputed: boolean
 
                         try {
-                            // Try creating the route - will fail if signature/contentHash already exists
+                            // Try creating the route - will fail if the topology signature already exists.
                             const route = await tx.route.create({
                                 data: {
-                                    contentHash,
                                     signature,
                                     length: 0, // Will be set below
                                     isConvergent: false, // Will be set below

--- a/src/lib/services/loaders/prediction-loader.service.ts
+++ b/src/lib/services/loaders/prediction-loader.service.ts
@@ -35,7 +35,6 @@ export interface PythonRoute {
     rank: number
     solvability?: Record<string, boolean>
     metadata?: Record<string, unknown>
-    content_hash: string
     signature: string
 }
 
@@ -522,9 +521,8 @@ export async function createRouteFromPython(
         throw new Error(`Target not found: ${targetId}`)
     }
 
-    // Read route properties from Python JSON
-    // Use content_hash and signature computed by Python, don't recompute
-    const contentHash = pythonRoute.content_hash
+    // Read route properties from Python JSON.
+    // SynthArena treats route identity as topology-only and deduplicates by signature.
     const signature = pythonRoute.signature
     const length = computeRouteLength(pythonRoute.target)
     const isConvergent = isRouteConvergent(pythonRoute.target)
@@ -544,7 +542,6 @@ export async function createRouteFromPython(
             const route = await tx.route.create({
                 data: {
                     signature,
-                    contentHash,
                     length,
                     isConvergent,
                 },

--- a/src/lib/services/view/route.view.ts
+++ b/src/lib/services/view/route.view.ts
@@ -148,13 +148,12 @@ function _buildComparisonNavigation(
  */
 export async function getAcceptableRoutesForTarget(
     targetId: string
-): Promise<Array<{ routeIndex: number; route: { id: string; contentHash: string | null; signature: string | null } }>> {
+): Promise<Array<{ routeIndex: number; route: { id: string; signature: string } }>> {
     const acceptableRoutes = await routeData.findAcceptableRoutesForTarget(targetId)
     return acceptableRoutes.map((ar) => ({
         routeIndex: ar.routeIndex,
         route: {
             id: ar.route.id,
-            contentHash: ar.route.contentHash,
             signature: ar.route.signature,
         },
     }))
@@ -197,7 +196,6 @@ export async function getAcceptableRouteData(routeId: string, targetId: string):
     const route: Route = {
         id: routeRecord.id,
         signature: routeRecord.signature,
-        contentHash: routeRecord.contentHash,
         length: routeRecord.length,
         isConvergent: routeRecord.isConvergent,
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -215,8 +215,7 @@ export interface AcceptableRoute {
  */
 export interface Route {
     id: string
-    signature: string // NOW REQUIRED: SHA256 of topology (unique constraint)
-    contentHash: string // SHA256 of full content (unique constraint)
+    signature: string // SHA256 of topology (unique constraint)
     length: number
     isConvergent: boolean
 }

--- a/tests/helpers/factories.ts
+++ b/tests/helpers/factories.ts
@@ -79,15 +79,12 @@ export function makeLinearPythonRoute(depth: number, rank: number = 1): PythonRo
         }
     }
 
-    // Generate deterministic content_hash and signature from the tree
     const treeJson = JSON.stringify(current)
-    const contentHash = crypto.createHash('sha256').update(treeJson).digest('hex')
     const signature = crypto.createHash('sha256').update(`sig-${treeJson}`).digest('hex')
 
     return {
         target: current,
         rank,
-        content_hash: contentHash,
         signature,
     }
 }
@@ -137,13 +134,11 @@ export function makeConvergentPythonRoute(depth: number, rank: number = 1): Pyth
     }
 
     const treeJson = JSON.stringify(final)
-    const contentHash = crypto.createHash('sha256').update(treeJson).digest('hex')
     const signature = crypto.createHash('sha256').update(`sig-${treeJson}`).digest('hex')
 
     return {
         target: final,
         rank,
-        content_hash: contentHash,
         signature,
     }
 }
@@ -183,13 +178,11 @@ export function makeBinaryTreePythonRoute(depth: number, rank: number = 1): Pyth
 
     const target = buildTree(depth)
     const treeJson = JSON.stringify(target)
-    const contentHash = crypto.createHash('sha256').update(treeJson).digest('hex')
     const signature = crypto.createHash('sha256').update(`sig-${treeJson}`).digest('hex')
 
     return {
         target,
         rank,
-        content_hash: contentHash,
         signature,
     }
 }
@@ -483,7 +476,6 @@ interface TestBenchmarkTarget {
     acceptable_routes: Array<{
         target: PythonMolecule
         rank: number
-        content_hash?: string
         signature?: string
         length?: number
         has_convergent_reaction?: boolean

--- a/tests/lib/services/loaders/benchmark-loader.integration.test.ts
+++ b/tests/lib/services/loaders/benchmark-loader.integration.test.ts
@@ -36,7 +36,6 @@ function makeBenchmarkTarget(
     acceptableRoutes: Array<{
         target: ReturnType<typeof makeLeafMolecule>
         rank: number
-        content_hash?: string
         signature?: string
         length?: number
         has_convergent_reaction?: boolean
@@ -102,7 +101,6 @@ describe('loadBenchmarkFromFile', () => {
                         {
                             target: route.target,
                             rank: 1,
-                            content_hash: route.content_hash,
                             signature: route.signature,
                             length: 2,
                             has_convergent_reaction: false,
@@ -160,7 +158,6 @@ describe('loadBenchmarkFromFile', () => {
                         {
                             target: route.target,
                             rank: 1,
-                            content_hash: route.content_hash,
                             signature: route.signature,
                             length: 1,
                             has_convergent_reaction: false,
@@ -175,7 +172,6 @@ describe('loadBenchmarkFromFile', () => {
                         {
                             target: route.target,
                             rank: 1,
-                            content_hash: route.content_hash,
                             signature: route.signature,
                             length: 1,
                             has_convergent_reaction: false,
@@ -201,7 +197,7 @@ describe('loadBenchmarkFromFile', () => {
         expect(acceptableRoutes).toHaveLength(2)
     })
 
-    it('throws when acceptable route is missing contentHash or signature', async () => {
+    it('throws when acceptable route is missing signature', async () => {
         const stock = await createStock({ name: 'bench-stock-missing-hash' })
         const benchmark = await createBenchmarkSet({ stockId: stock.id, name: 'bench-missing' })
 
@@ -218,7 +214,7 @@ describe('loadBenchmarkFromFile', () => {
                         {
                             target: route.target,
                             rank: 1,
-                            // Missing content_hash and signature!
+                            // Missing signature!
                         },
                     ],
                 },
@@ -248,7 +244,6 @@ describe('loadBenchmarkFromFile', () => {
                         {
                             target: route.target,
                             rank: 1,
-                            content_hash: route.content_hash,
                             signature: route.signature,
                             length: 3,
                             has_convergent_reaction: false,
@@ -283,7 +278,6 @@ describe('loadBenchmarkFromFile', () => {
                         {
                             target: route.target,
                             rank: 1,
-                            content_hash: route.content_hash,
                             signature: route.signature,
                             // No length or has_convergent_reaction — must be computed
                         },
@@ -325,7 +319,6 @@ describe('loadBenchmarkFromFile', () => {
                         {
                             target: route.target,
                             rank: 1,
-                            content_hash: route.content_hash,
                             signature: route.signature,
                             length: 1,
                             has_convergent_reaction: false,
@@ -367,7 +360,6 @@ describe('loadBenchmarkFromFile', () => {
                         {
                             target: route.target,
                             rank: 1,
-                            content_hash: route.content_hash,
                             signature: route.signature,
                             length: 2,
                             has_convergent_reaction: false,
@@ -426,7 +418,6 @@ describe('loadBenchmarkFromFile', () => {
                         {
                             target: route.target,
                             rank: 1,
-                            content_hash: route.content_hash,
                             signature: route.signature,
                             length: 2,
                             has_convergent_reaction: true,
@@ -464,7 +455,6 @@ describe('loadBenchmarkFromFile', () => {
                         {
                             target: route1.target,
                             rank: 1,
-                            content_hash: route1.content_hash,
                             signature: route1.signature,
                             length: 1,
                             has_convergent_reaction: false,
@@ -472,7 +462,6 @@ describe('loadBenchmarkFromFile', () => {
                         {
                             target: route2.target,
                             rank: 2,
-                            content_hash: route2.content_hash,
                             signature: route2.signature,
                             length: 3,
                             has_convergent_reaction: false,
@@ -524,7 +513,6 @@ describe('loadBenchmarkFromFile', () => {
                         {
                             target: route.target,
                             rank: 1,
-                            content_hash: route.content_hash,
                             signature: route.signature,
                             length: 1,
                             has_convergent_reaction: false,
@@ -554,7 +542,6 @@ describe('loadBenchmarkFromFile', () => {
                         {
                             target: route.target, // same route tree as above
                             rank: 1,
-                            content_hash: route.content_hash,
                             signature: route.signature, // same signature → route will be reused
                             length: 1,
                             has_convergent_reaction: false,

--- a/tests/lib/services/loaders/loader-roundtrip.integration.test.ts
+++ b/tests/lib/services/loaders/loader-roundtrip.integration.test.ts
@@ -80,7 +80,6 @@ describe('loader roundtrip', () => {
                         {
                             target: benchRoute.target,
                             rank: 1,
-                            content_hash: benchRoute.content_hash,
                             signature: benchRoute.signature,
                             length: 2,
                             has_convergent_reaction: false,
@@ -263,7 +262,6 @@ describe('loader roundtrip', () => {
                         {
                             target: convergentRoute.target,
                             rank: 1,
-                            content_hash: convergentRoute.content_hash,
                             signature: convergentRoute.signature,
                             // Omit length & has_convergent_reaction — force benchmark-loader to compute them
                         },

--- a/tests/lib/services/view/leaderboard.integration.test.ts
+++ b/tests/lib/services/view/leaderboard.integration.test.ts
@@ -84,7 +84,6 @@ async function setupLeaderboardContext(label: string) {
                     {
                         target: route.target,
                         rank: 1,
-                        content_hash: route.content_hash,
                         signature: route.signature,
                         length: 2,
                         has_convergent_reaction: false,


### PR DESCRIPTION
## what changed

this pr removes `route.contentHash` from syntharena and makes route identity topology-only via `Route.signature`.

it updates the prisma schema, loaders, route read/view types, and target header ui so syntharena stops presenting `content_hash` as authoritative route identity.

it also adds a migration that:
- drops `Route.contentHash`
- rebuilds `RouteNode` with the missing `reactionStepId` foreign key

finally, it makes `scripts/migrate-reaction-steps.ts` accept `DB_PATH` so the reaction-step rollout can be applied to arbitrary sqlite copies such as `prod.db`.

## why this changed

retrocast uses `content_hash` for exact payload/provenance identity, but syntharena actually deduplicates and visualizes routes by topology signature. keeping `contentHash` on the canonical `Route` row created a semantic mismatch and surfaced untrustworthy values in the ui.

this change makes syntharena honest about its route model:
- `Route` is topology
- planner/benchmark payload detail is not treated as canonical route identity

## root cause

the schema and ui implied that syntharena mirrored retrocast's exact route payload identity, but the loaders reused routes by `signature` alone. that meant `contentHash` could not be trusted after import.

## impact

- route signature remains the stable route identity in syntharena
- route content hash is removed from schema and ui
- the sqlite migration path is now explicit and reproducible for pre-reaction-step databases

## validation

- `pnpm --dir syntharena exec prisma validate --schema prisma/schema.prisma`
- `pnpm --dir syntharena exec tsc --noEmit`
- `pnpm --dir syntharena exec vitest run tests/lib/services/loaders/benchmark-loader.integration.test.ts tests/lib/services/loaders/loader-roundtrip.integration.test.ts tests/lib/services/view/leaderboard.integration.test.ts`
- `pnpm --dir syntharena exec prisma migrate diff --from-config-datasource --to-schema prisma/schema.prisma --exit-code`

## note

local sqlite upgrade flow was exercised on a copied `prod.db` and then on the local in-place `prisma/prod.db` using:
1. `prisma migrate deploy`
2. `DB_PATH=... pnpm exec tsx scripts/migrate-reaction-steps.ts`
3. `prisma migrate resolve --rolled-back 20260315000001_drop_deprecated_routenode_columns`
4. `prisma migrate deploy`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ischemist/codesmith/syntharena/pr/72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `contentHash` from Route model and replace with signature-only identity
> - Drops the `contentHash` column from the `Route` table via a new Prisma migration, leaving `signature` as the sole unique identifier for routes.
> - Removes `content_hash` from the `PythonRoute` interface, route creation, deduplication logic, and all test fixtures across loaders and view services.
> - Strips `contentHash` from the `TargetHeader` UI component and all route DTOs returned by data/view layers.
> - Risk: Any queries or writes referencing `contentHash` will fail at runtime after migration.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 95fd885.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes `Route.contentHash` from the schema, data layer, view layer, and UI, making `signature` the sole route identity in syntharena. It also adds a SQLite migration that rebuilds both `Route` (dropping `contentHash`) and `RouteNode` (adding the previously-missing `reactionStepId` foreign key), and updates `migrate-reaction-steps.ts` to accept a `DB_PATH` env var for running on arbitrary database copies.

<h3>Confidence Score: 5/5</h3>

Safe to merge — migration, schema, service layer, and tests are all consistent with the removal.

All changes are consistently aligned: the migration correctly uses the SQLite table-rebuild pattern, the schema matches, service layer DTOs no longer reference contentHash, and integration tests are updated throughout. The dual-purpose migration (drops contentHash + adds reactionStepId FK) is well-documented, and the pre-reaction-step upgrade flow described in the PR notes is sound.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| prisma/migrations/20260421170000_remove_route_content_hash/migration.sql | Drops Route.contentHash via standard SQLite table rebuild and simultaneously adds the missing reactionStepId FK to RouteNode. |
| prisma/schema.prisma | Removes contentHash field from Route model; cleans up RouteNode whitespace; updates ReactionStep comments to reflect topology-level semantics. |
| scripts/migrate-reaction-steps.ts | Adds DB_PATH env var support (defaulting to prisma/dev.db) to allow running the migration on arbitrary SQLite copies like prod.db. |
| src/app/benchmarks/[benchmarkId]/targets/[targetId]/_components/server/target-header.tsx | Replaces content hash display with route signature; adds HoverCard explaining the topology-only semantics of the signature. |
| src/lib/services/data/route.data.ts | findAcceptableRoutesForTarget now selects only { id, signature } — contentHash removed from Route select projections. |
| src/lib/services/loaders/benchmark-loader.service.ts | Removes content_hash from PythonRoute interface; route creation now uses signature-only deduplication throughout. |
| src/types/index.ts | Route interface drops contentHash field; signature remains the sole unique identifier matching updated schema. |
| tests/helpers/factories.ts | TestBenchmarkTarget.acceptable_routes type no longer includes content_hash; PythonRoute factories match updated interface. |

</details>

<h3>Entity Relationship Diagram</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
erDiagram
    Route {
        string id PK
        string signature UK "SHA256 topology (sole identity)"
        int length
        boolean isConvergent
    }
    RouteNode {
        string id PK
        string routeId FK
        string moleculeId FK
        string parentId FK
        string reactionStepId FK "NEW: FK to ReactionStep"
        boolean isLeaf
    }
    ReactionStep {
        string id PK
        string reactionHash UK
        string template
        string metadata
    }
    AcceptableRoute {
        string id PK
        string benchmarkTargetId FK
        string routeId FK
        int routeIndex
    }
    PredictionRoute {
        string id PK
        string routeId FK
        string predictionRunId FK
        string targetId FK
        int rank
    }

    Route ||--o{ RouteNode : "has nodes"
    Route ||--o{ AcceptableRoute : "referenced by"
    Route ||--o{ PredictionRoute : "predicted as"
    RouteNode }o--|| ReactionStep : "references"
    RouteNode }o--o| RouteNode : "parent"
```

<sub>Reviews (1): Last reviewed commit: ["remove route content hash from syntharen..."](https://github.com/ischemist/syntharena/commit/95fd88509398e3a3a9609165d45fe2b17fdcd6e6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29157333)</sub>

<!-- /greptile_comment -->