### PR TITLE
add health endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ prisma/dev.db*
 AGENTS.md
 
 collect/
+
+.practices/

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The platform will be available at [http://localhost:3000](http://localhost:3000)
 
 ### Health Check
 
-`GET /api/health` returns `200` when the Next.js app can reach the SQLite database and `503` when the database check fails. It is intended for uptime monitors such as Better Stack.
+`GET /api/health` returns `200` when the Next.js app can reach the SQLite database and `503` with `health.database_unavailable` when the database check fails. It is intended for uptime monitors such as Better Stack.
 
 ### Environment Configuration
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ pnpm dev
 
 The platform will be available at [http://localhost:3000](http://localhost:3000)
 
+### Health Check
+
+`GET /api/health` returns `200` when the Next.js app can reach the SQLite database and `503` when the database check fails. It is intended for uptime monitors such as Better Stack.
+
 ### Environment Configuration
 
 The `.env` file requires only one variable:

--- a/ischemist.toml
+++ b/ischemist.toml
@@ -1,0 +1,4 @@
+[practices]
+source = "/Users/morgunov/Developer/engineering-practices"
+profile = "next-prisma-app"
+output = ".practices/docs"

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -5,6 +5,8 @@ import prisma from '@/lib/db'
 export const dynamic = 'force-dynamic'
 export const runtime = 'nodejs'
 
+const DATABASE_CHECK_TIMEOUT_MS = 1000
+
 type HealthPayload = {
     ok: boolean
     service: 'syntharena'
@@ -14,6 +16,16 @@ type HealthPayload = {
     timestamp: string
     code?: 'health.database_unavailable'
     message?: string
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+    let timeout: NodeJS.Timeout
+
+    const timeoutPromise = new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => reject(new Error('health.database_check_timeout')), timeoutMs)
+    })
+
+    return Promise.race([promise, timeoutPromise]).finally(() => clearTimeout(timeout))
 }
 
 export async function GET() {
@@ -27,9 +39,10 @@ export async function GET() {
     }
 
     try {
-        await prisma.$queryRaw`SELECT 1`
+        // Health probes are intentionally uncached so monitors see current app/database availability.
+        await withTimeout(prisma.$queryRaw`SELECT 1`, DATABASE_CHECK_TIMEOUT_MS)
     } catch (error) {
-        console.error('health.database_check_failed', { error })
+        console.error('health.database_check_failed', error)
         payload.ok = false
         payload.checks.database = 'error'
         payload.code = 'health.database_unavailable'

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server'
+
+import prisma from '@/lib/db'
+
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
+type HealthPayload = {
+    ok: boolean
+    service: 'syntharena'
+    checks: {
+        database: 'ok' | 'error'
+    }
+    timestamp: string
+    code?: 'health.database_unavailable'
+    message?: string
+}
+
+export async function GET() {
+    const payload: HealthPayload = {
+        ok: true,
+        service: 'syntharena',
+        checks: {
+            database: 'ok',
+        },
+        timestamp: new Date().toISOString(),
+    }
+
+    try {
+        await prisma.$queryRaw`SELECT 1`
+    } catch (error) {
+        console.error('health.database_check_failed', { error })
+        payload.ok = false
+        payload.checks.database = 'error'
+        payload.code = 'health.database_unavailable'
+        payload.message = 'Database unavailable.'
+    }
+
+    return NextResponse.json(payload, {
+        status: payload.ok ? 200 : 503,
+        headers: {
+            'Cache-Control': 'no-store',
+        },
+    })
+}


### PR DESCRIPTION
## problem

syntharena did not have a small public health endpoint for uptime monitoring.

## approach

- add `GET /api/health` as a dynamic node route handler
- check sqlite connectivity through prisma with `SELECT 1`
- return `200` when healthy and `503` with a stable code when the database check fails
- log database check failures with the original error for production debugging
- document the endpoint in the readme

## risk

low. this adds a read-only endpoint with no writes, no cache invalidation, and no user-visible ui changes. the main operational behavior is that monitors can now distinguish app/db availability.

## verification

- `DATABASE_URL='file:./prisma/dev.db' COREPACK_ENABLE_AUTO_PIN=0 pnpm check-types`
- `COREPACK_ENABLE_AUTO_PIN=0 pnpm lint`
- local smoke: `curl http://localhost:3001/api/health` returned `200` with `{"ok":true,"service":"syntharena","checks":{"database":"ok"}}`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ischemist/codesmith/syntharena/pr/74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add GET /api/health endpoint with database liveness check
> - Adds [src/app/api/health/route.ts](https://github.com/ischemist/syntharena/pull/74/files#diff-4b5c18fc820c113c3d55f9073f3b0d8a17cc25a05a0294d458bc0897afb91abf) with a Next.js route handler that queries the SQLite database via `prisma.$queryRaw\`SELECT 1\`` and returns `200` on success or `503` with code `health.database_unavailable` on failure.
> - A `withTimeout` utility wraps the DB query in a `Promise.race`, rejecting with `health.database_check_timeout` after 1000ms.
> - Response includes a `HealthPayload` JSON body and `Cache-Control: no-store` to prevent caching by uptime monitors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8b31b19.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a health check API endpoint for uptime monitoring, returning service status and database connectivity information with appropriate HTTP status codes (200 for healthy, 503 when unavailable).

* **Documentation**
  * Updated README with Health Check section documenting endpoint behavior and expected responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Adds `GET /api/health` as a force-dynamic Node.js route that runs a 1 s-timeout `SELECT 1` via Prisma and returns `200` (healthy) or `503` with `health.database_unavailable` (database unreachable), with `Cache-Control: no-store` on all responses.
- Documents the endpoint in `README.md` for uptime monitors and correctly gitignores the generated `.practices/` output directory.
- `ischemist.toml` is committed with a hard-coded absolute local path that will not resolve on any other developer's machine.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the only issue is a developer-local path in ischemist.toml, which is a P2 maintenance concern.

All findings are P2. The health endpoint implementation is correct: timeout guard, proper status codes, direct error logging, and Cache-Control: no-store. No security, data integrity, or runtime correctness issues.

ischemist.toml — hardcoded absolute path will not resolve on other developers' machines.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/app/api/health/route.ts | New force-dynamic Node.js health route; performs a 1 s-timeout SELECT 1 via Prisma, returns 200/503 JSON with Cache-Control: no-store. Implementation is clean and correct. |
| ischemist.toml | New config file for ischemist tooling; hard-codes an absolute local filesystem path that won't resolve on any other developer's machine. |
| README.md | Adds a concise Health Check section documenting the new endpoint's status codes and intended use. |
| .gitignore | Adds .practices/ to ignore list, correctly excluding generated ischemist output. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Monitor as Uptime Monitor
    participant Route as GET /api/health
    participant Prisma as Prisma (SQLite)

    Monitor->>Route: GET /api/health
    Route->>Prisma: $queryRaw SELECT 1 (1s timeout)
    alt Database reachable
        Prisma-->>Route: result
        Route-->>Monitor: 200 {ok: true, checks: {database: ok}}
    else Timeout or error
        Prisma-->>Route: Error / timeout
        Route->>Route: console.error + mutate payload
        Route-->>Monitor: 503 {ok: false, code: health.database_unavailable}
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
ischemist.toml:2
The `source` path is an absolute path pointing to the author's local machine. Any other developer cloning this repo who tries to run the `ischemist` tooling will fail immediately because `/Users/morgunov/Developer/engineering-practices` won't exist on their machine. Consider using a `~`-relative path, an environment variable, or adding this file to `.gitignore` alongside the already-ignored `.practices/` output.

```suggestion
source = "~/Developer/engineering-practices"
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["address health endpoint review"](https://github.com/ischemist/syntharena/commit/8b31b19bfed8b9a59e15230666ca428428653da3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30854677)</sub>

<!-- /greptile_comment -->