### PR TITLE
chore: release 0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "syntharena",
-    "version": "0.1.0",
+    "version": "0.4.1",
     "private": true,
     "scripts": {
         "dev": "next dev",

--- a/src/app/(info)/changelog/page.tsx
+++ b/src/app/(info)/changelog/page.tsx
@@ -9,6 +9,26 @@ export const metadata: Metadata = {
 
 const versions = [
     {
+        version: 'v0.4.1',
+        date: 'May 5, 2026',
+        changes: [
+            {
+                type: ChangeType.FEAT,
+                description:
+                    'Added a health endpoint for uptime monitoring and the public status page at status.ischemist.com',
+            },
+            {
+                type: ChangeType.BUGFIX,
+                description: 'Security dependency updates across Next.js, Rollup, flatted, and related npm packages',
+            },
+            {
+                type: ChangeType.PERF,
+                description:
+                    'Shared route visualization packages and route payload cleanup for faster, leaner route pages',
+            },
+        ],
+    },
+    {
         version: 'v0.4.0',
         date: 'January 27, 2026',
         changes: [


### PR DESCRIPTION
## summary
- bump syntharena package version to 0.4.1
- add v0.4.1 changelog entry covering the health endpoint and public status page at status.ischemist.com
- summarize dependency security fixes, shared route visualization cleanup, perf improvements, and ci/test coverage work

## verification
- pnpm format:check
- pnpm check-types

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ischemist/codesmith/syntharena/pr/75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Release version 0.4.1
> Bumps the package version to 0.4.1 in [package.json](https://github.com/ischemist/syntharena/pull/75/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) and adds a corresponding entry to the [changelog page](https://github.com/ischemist/syntharena/pull/75/files#diff-ee5d98254fb383494ee8a4e4f2dd0843da1970e3ea7e11b09d626bd64abcfb4a) documenting a new health endpoint and public status page, security dependency updates, and route visualization payload optimizations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9df40bc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Bumps `package.json` version from `0.1.0` to `0.4.1` (private package, no npm impact) and prepends a v0.4.1 entry to the changelog page covering the health/status endpoint, security dependency updates, and route visualization performance work.
- The PR description mentions CI/regression test coverage improvements, but no corresponding changelog entry was added; this appears intentional (CI work is not user-facing).
- No logic, type, or rendering issues detected in either changed file.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are purely documentation and version metadata with no logic impact.

Only two files changed: a version string in a private package and a static changelog array. No runtime logic, no API surface, no security concerns. All ChangeType values match existing enum members and the entry structure is consistent with the rest of the changelog.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| package.json | Version bumped from 0.1.0 to 0.4.1; package is private so no npm publishing impact. |
| src/app/(info)/changelog/page.tsx | New v0.4.1 changelog entry prepended with three changes (FEAT, BUGFIX, PERF); structure and ChangeType usage are consistent with existing entries. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Release PR #75] --> B[package.json\nversion: 0.1.0 → 0.4.1]
    A --> C[changelog/page.tsx\nprepend v0.4.1 entry]
    C --> D[ChangeType.FEAT\nHealth endpoint & status page]
    C --> E[ChangeType.BUGFIX\nSecurity dependency updates]
    C --> F[ChangeType.PERF\nRoute visualization cleanup]
```

<sub>Reviews (2): Last reviewed commit: ["chore: release 0.4.1"](https://github.com/ischemist/syntharena/commit/9df40bc3ebb3c01efad8b1a0e57cfd0b74a73918) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30858911)</sub>

<!-- /greptile_comment -->