### PR TITLE
feat: add crosslinks from /thesis page to newer /syntax-of-matter

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ The platform will be available at [http://localhost:3000](http://localhost:3000)
 
 `GET /api/health` returns `200` when the Next.js app can reach the SQLite database and `503` with `health.database_unavailable` when the database check fails. It is intended for uptime monitors such as Better Stack.
 
+The hosted deployment is monitored at [status.ischemist.com](https://status.ischemist.com).
+
 ### Environment Configuration
 
 For Docker, `docker-compose.yml` sets the container database path:
@@ -310,6 +312,7 @@ MIT License. See [LICENSE](LICENSE) for details.
 - **Paper:** [arxiv.org/abs/2512.07079](https://arxiv.org/abs/2512.07079)
 - **Publication Data:** [files.ischemist.com/retrocast/publication-data](https://files.ischemist.com/retrocast/publication-data)
 - **Live Platform:** [syntharena.ischemist.com](https://syntharena.ischemist.com)
+- **Service Status:** [status.ischemist.com](https://status.ischemist.com)
 
 ---
 

--- a/src/app/(info)/changelog/_components/version-block.tsx
+++ b/src/app/(info)/changelog/_components/version-block.tsx
@@ -1,8 +1,10 @@
+import type { ReactNode } from 'react'
+
 import { ChangeType, ChangeTypeBadge } from './change-type-badge'
 
 interface Change {
     type: ChangeType
-    description: string
+    description: ReactNode
 }
 
 interface VersionBlockProps {

--- a/src/app/(info)/changelog/page.tsx
+++ b/src/app/(info)/changelog/page.tsx
@@ -14,8 +14,19 @@ const versions = [
         changes: [
             {
                 type: ChangeType.FEAT,
-                description:
-                    'Added a health endpoint for uptime monitoring and the public status page at status.ischemist.com',
+                description: (
+                    <>
+                        Added a health endpoint for uptime monitoring and the public status page at{' '}
+                        <a
+                            href="https://status.ischemist.com"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-foreground hover:underline"
+                        >
+                            status.ischemist.com
+                        </a>
+                    </>
+                ),
             },
             {
                 type: ChangeType.BUGFIX,

--- a/src/app/(info)/docs/page.tsx
+++ b/src/app/(info)/docs/page.tsx
@@ -3,6 +3,8 @@ import Link from 'next/link'
 
 import { Card, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 
+import { IschemistUpdatesSection } from '../../_components/server/ischemist-updates-section'
+
 export const metadata: Metadata = {
     title: 'Documentation',
     description: 'Learn how SynthArena evaluates multistep retrosynthesis models',
@@ -111,6 +113,8 @@ export default function DocsPage() {
                         </a>
                     </div>
                 </section>
+
+                <IschemistUpdatesSection />
             </div>
         </div>
     )

--- a/src/app/(info)/thesis/_components/hero-section.tsx
+++ b/src/app/(info)/thesis/_components/hero-section.tsx
@@ -1,6 +1,9 @@
 export function HeroSection() {
     return (
         <header className="space-y-6">
+            <p className="text-muted-foreground text-sm font-medium tracking-wide uppercase">
+                First published December 10, 2025
+            </p>
             <h1 className="text-3xl leading-tight tracking-tight">
                 The most transformative successes in artificial intelligence have a common pattern:{' '}
                 <span className="font-normal">they solved </span> <span className="font-bold">structural</span> problems

--- a/src/app/(info)/thesis/page.tsx
+++ b/src/app/(info)/thesis/page.tsx
@@ -27,7 +27,7 @@ export default function ThesisPage() {
                 <ValiditySection />
                 <EvaluationTrackSection />
 
-                <footer className="text-muted-foreground not-prose mt-8! space-y-4 border-t pt-6 text-sm">
+                <footer className="text-muted-foreground not-prose !mt-8 space-y-4 border-t pt-6 text-sm">
                     <div className="space-y-2">
                         <p>
                             This December 2025 thesis was the first statement of the argument. It later broadened into{' '}

--- a/src/app/(info)/thesis/page.tsx
+++ b/src/app/(info)/thesis/page.tsx
@@ -27,7 +27,30 @@ export default function ThesisPage() {
                 <ValiditySection />
                 <EvaluationTrackSection />
 
-                <footer className="text-muted-foreground not-prose border-t pt-8 text-sm">
+                <footer className="text-muted-foreground not-prose mt-8! space-y-4 border-t pt-6 text-sm">
+                    <div className="space-y-2">
+                        <p>
+                            This December 2025 thesis was the first statement of the argument. It later broadened into{' '}
+                            <a
+                                href="https://ischemist.com/thesis"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-foreground hover:underline"
+                            >
+                                ischemist.com/thesis
+                            </a>
+                            , then into{' '}
+                            <a
+                                href="https://ischemist.com/syntax-of-matter"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-foreground hover:underline"
+                            >
+                                Syntax of Matter
+                            </a>
+                            .
+                        </p>
+                    </div>
                     <p>
                         <a
                             href="https://arxiv.org/abs/2512.07079"

--- a/src/app/_components/client/app-sidebar.tsx
+++ b/src/app/_components/client/app-sidebar.tsx
@@ -143,7 +143,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                     <div className="border-sidebar-border text-sidebar-foreground/70 space-y-2 border-t px-2 pt-3 text-xs">
                         <p className="font-medium text-sidebar-foreground">From isChemist</p>
                         <p className="leading-snug">
-                            Software, essays, and tools that make better scientific questions possible.
+                            Essays and software that make better scientific questions possible.
                         </p>
                         <div className="flex items-center gap-3">
                             <a

--- a/src/app/_components/client/app-sidebar.tsx
+++ b/src/app/_components/client/app-sidebar.tsx
@@ -6,10 +6,12 @@ import {
     Beaker,
     BookOpen,
     Cpu,
+    Activity,
     FlaskConical,
     History,
     LayoutDashboard,
     Lightbulb,
+    Mail,
     Map,
     Trophy,
     Upload,
@@ -136,7 +138,36 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                 <NavDropdowns items={data.navDropdowns} />
                 <NavSecondary items={data.navSecondary} className="mt-auto" />
             </SidebarContent>
-            <SidebarFooter>{/*<NavUser user={data.user} />*/}</SidebarFooter>
+            <SidebarFooter>
+                <div className="group-data-[collapsible=icon]:hidden">
+                    <div className="border-sidebar-border text-sidebar-foreground/70 space-y-2 border-t px-2 pt-3 text-xs">
+                        <p className="font-medium text-sidebar-foreground">From isChemist</p>
+                        <p className="leading-snug">
+                            Software, essays, and tools that make better scientific questions possible.
+                        </p>
+                        <div className="flex items-center gap-3">
+                            <a
+                                href="https://ischemist.com/newsletter"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="hover:text-sidebar-foreground inline-flex items-center gap-1 transition-colors"
+                            >
+                                <Mail className="size-3" />
+                                Newsletter
+                            </a>
+                            <a
+                                href="https://status.ischemist.com"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="hover:text-sidebar-foreground inline-flex items-center gap-1 transition-colors"
+                            >
+                                <Activity className="size-3" />
+                                Status
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </SidebarFooter>
         </Sidebar>
     )
 }

--- a/src/app/_components/server/ischemist-updates-section.tsx
+++ b/src/app/_components/server/ischemist-updates-section.tsx
@@ -1,0 +1,35 @@
+import { Activity, Mail } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+
+export function IschemistUpdatesSection() {
+    return (
+        <section className="border-t py-8">
+            <div className="max-w-xl space-y-4">
+                <div className="space-y-2">
+                    <p className="text-foreground text-xs font-medium tracking-wide uppercase">From isChemist</p>
+                    <p className="text-foreground text-sm leading-relaxed">
+                        Software, essays, and tools that make better scientific questions possible.
+                    </p>
+                    <p className="text-muted-foreground text-sm leading-relaxed">
+                        Subscribe for notes from the edge of AI for chemistry.
+                    </p>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                    <Button asChild size="sm">
+                        <a href="https://ischemist.com/newsletter" target="_blank" rel="noopener noreferrer">
+                            <Mail className="size-4" />
+                            Newsletter
+                        </a>
+                    </Button>
+                    <Button asChild variant="outline" size="sm">
+                        <a href="https://status.ischemist.com" target="_blank" rel="noopener noreferrer">
+                            <Activity className="size-4" />
+                            Service status
+                        </a>
+                    </Button>
+                </div>
+            </div>
+        </section>
+    )
+}

--- a/src/app/_components/server/ischemist-updates-section.tsx
+++ b/src/app/_components/server/ischemist-updates-section.tsx
@@ -7,12 +7,11 @@ export function IschemistUpdatesSection() {
         <section className="border-t py-8">
             <div className="max-w-xl space-y-4">
                 <div className="space-y-2">
-                    <p className="text-foreground text-xs font-medium tracking-wide uppercase">From isChemist</p>
-                    <p className="text-foreground text-sm leading-relaxed">
-                        Software, essays, and tools that make better scientific questions possible.
+                    <p className="text-foreground text-xs font-medium tracking-wide uppercase">
+                        From isChemist: Structure precedes quantity.
                     </p>
                     <p className="text-muted-foreground text-sm leading-relaxed">
-                        Subscribe for notes from the edge of AI for chemistry.
+                        Essays and software that make better scientific questions possible.
                     </p>
                 </div>
                 <div className="flex flex-wrap gap-2">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from 'react'
 
 import { BenchmarksOverviewSection } from './_components/server/benchmarks-overview-section'
 import { HeaderSection } from './_components/server/header-section'
+import { IschemistUpdatesSection } from './_components/server/ischemist-updates-section'
 import { LiveStatsSection } from './_components/server/live-stats-section'
 import { NavigationSection } from './_components/server/navigation-section'
 import { ProblemSolutionSection } from './_components/server/problem-solution-section'
@@ -9,7 +10,7 @@ import { BenchmarksTableSkeleton, StatsTableSkeleton } from './_components/skele
 
 export default function Home() {
     return (
-        <div className="container mx-auto max-w-7xl space-y-0 py-8">
+        <div className="container mx-auto max-w-7xl space-y-0 pb-8">
             <HeaderSection />
             <ProblemSolutionSection />
             <Suspense fallback={<StatsTableSkeleton />}>
@@ -19,6 +20,7 @@ export default function Home() {
                 <BenchmarksOverviewSection />
             </Suspense>
             <NavigationSection />
+            <IschemistUpdatesSection />
         </div>
     )
 }


### PR DESCRIPTION
## why

SynthArena is now part of a broader isChemist distribution surface: hosted users need a clear status link, and readers who find the platform or docs should have a non-intrusive path into the broader work behind it.

## what changed

- Added a quiet From isChemist callout to the homepage and docs page with newsletter and service-status links.
- Added persistent sidebar links for the newsletter and status page.
- Linked the status page from the changelog and README health-check/related-resources sections.
- Dated the SynthArena thesis and added links to the later personal thesis and Syntax of Matter progression.

## risk

Low. The change is UI/docs copy and external links only. No database writes, auth paths, migrations, cache behavior, or deployment runtime logic changed.

## verification

- COREPACK_ENABLE_AUTO_PIN=0 pnpm format:check
- COREPACK_ENABLE_AUTO_PIN=0 pnpm check-types
- COREPACK_ENABLE_AUTO_PIN=0 pnpm lint
- Local smoke earlier on / and /docs before the README amend

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ischemist/codesmith/syntharena/pr/78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a visible "From isChemist" updates section (newsletter + service status links) to Home and Docs; sidebar footer now shows newsletter and status links.

* **Documentation**
  * README updated with a Service Status link.
  * Thesis page shows publication date and an expanded footer narrative.
  * Changelog entries now support richer content and inline external links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds isChemist branding/update links across the homepage, docs, sidebar, thesis, and changelog pages, along with a new `IschemistUpdatesSection` server component. All changes are UI copy and external links with no backend, auth, or data-layer impact.

- **New component** `ischemist-updates-section.tsx` is used on both the homepage and docs page to surface a newsletter button and a service-status button; all `<a>` tags correctly include `rel=\"noopener noreferrer\"`.
- **Sidebar footer** gains newsletter and status links hidden when the sidebar is collapsed (`group-data-[collapsible=icon]:hidden`), and `version-block.tsx` widens `description` from `string` to `ReactNode` to support inline hyperlinks in changelog entries.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are UI copy and external links with no logic, data, or auth paths touched.

The diff adds static text, external hyperlinks, and a small new server component. No database writes, API routes, auth flows, migrations, or runtime logic are modified. Every target="_blank" link carries rel="noopener noreferrer". The ReactNode widening in version-block.tsx is a purely additive type change that doesn't break existing string descriptions.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/app/_components/server/ischemist-updates-section.tsx | New server component rendering a newsletter + status callout block with correct rel="noopener noreferrer" on all external links. |
| src/app/_components/client/app-sidebar.tsx | Adds sidebar footer with newsletter/status links; Activity and Mail imports added out of alphabetical order relative to the rest of the block (already noted in a prior review comment). |
| src/app/page.tsx | Adds IschemistUpdatesSection at page bottom; py-8 narrowed to pb-8 (already flagged in a prior review thread). |
| src/app/(info)/thesis/page.tsx | Footer extended with links to the broader thesis and Syntax of Matter; uses Tailwind important modifier !mt-8 to override prose spacing. |
| src/app/(info)/changelog/_components/version-block.tsx | description field widened from string to ReactNode to support inline links; safe type-only change. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[page.tsx\nHomepage] --> B[IschemistUpdatesSection]
    C[docs/page.tsx\nDocs] --> B
    B --> D[ischemist.com/newsletter]
    B --> E[status.ischemist.com]

    F[app-sidebar.tsx\nSidebar Footer] --> D
    F --> E

    G[thesis/page.tsx\nThesis Footer] --> H[ischemist.com/thesis]
    G --> I[ischemist.com/syntax-of-matter]

    J[changelog/page.tsx] --> K[VersionBlock\nReactNode description]
    K --> E
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/app/_components/client/app-sidebar.tsx`, line 4-15 ([link](https://github.com/ischemist/syntharena/blob/4f90f9507db7bb1df47931a205349ce0e022bb29/src/app/_components/client/app-sidebar.tsx#L4-L15)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> `Activity` is inserted after `Cpu` but the block is otherwise sorted A→Z — `Activity` should come first (before `BarChart3`).

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/app/_components/client/app-sidebar.tsx
   Line: 4-15

   Comment:
   `Activity` is inserted after `Cpu` but the block is otherwise sorted A→Z — `Activity` should come first (before `BarChart3`).

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix: correct thesis footer spacing utili..."](https://github.com/ischemist/syntharena/commit/2b843fdae8d53261674a7fa01669075b1ff4593c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31193182)</sub>

<!-- /greptile_comment -->