### PR TITLE
fix: upgrade ci to pnpm 11

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -11,13 +11,11 @@ jobs:
         runs-on: blacksmith-4vcpu-ubuntu-2204
         strategy:
             matrix:
-                node-version: [20]
+                node-version: [22]
         steps:
             - uses: actions/checkout@v4
             - name: Install pnpm
               uses: pnpm/action-setup@v4
-              with:
-                  version: 10
             - name: Use Node.js ${{ matrix.node-version }}
               uses: actions/setup-node@v4
               with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,13 +21,11 @@ jobs:
 
             - name: Install pnpm
               uses: pnpm/action-setup@v4
-              with:
-                  version: 10
 
             - name: Setup Node.js
               uses: actions/setup-node@v4
               with:
-                  node-version: '20'
+                  node-version: '22'
                   cache: 'pnpm'
 
             - name: Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update \
     && chown syntharena:syntharena /app
 
 FROM base AS deps
-RUN corepack enable && corepack prepare pnpm@10.33.4 --activate
+RUN corepack enable && corepack prepare pnpm@11.0.8 --activate
 USER syntharena
 COPY --chown=syntharena:syntharena package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -94,5 +94,5 @@
             "oxfmt --no-error-on-unmatched-pattern"
         ]
     },
-    "packageManager": "pnpm@10.33.4"
+    "packageManager": "pnpm@11.0.8"
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "date-fns": "^4.1.0",
         "dotenv": "^17.2.3",
         "lucide-react": "^0.554.0",
-        "next": "^16.2.3",
+        "next": "^16.2.6",
         "next-themes": "^0.4.6",
         "react": "19.2.0",
         "react-dom": "19.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,8 +102,8 @@ importers:
         specifier: ^0.554.0
         version: 0.554.0(react@19.2.0)
       next:
-        specifier: ^16.2.3
-        version: 16.2.3(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: ^16.2.6
+        version: 16.2.6(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -823,57 +823,57 @@ packages:
     resolution: {integrity: sha512-JwqeCQ1U3fvccttHZq7Tk0m/TMC6WcFAQZdukypW3AzlJYKYTGNVd1ANU2GuhKnv4UQuOFj3oAl0LLG/gxFN1w==}
     engines: {node: '>=16'}
 
-  '@next/env@16.2.3':
-    resolution: {integrity: sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==}
+  '@next/env@16.2.6':
+    resolution: {integrity: sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==}
 
-  '@next/swc-darwin-arm64@16.2.3':
-    resolution: {integrity: sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg==}
+  '@next/swc-darwin-arm64@16.2.6':
+    resolution: {integrity: sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.2.3':
-    resolution: {integrity: sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ==}
+  '@next/swc-darwin-x64@16.2.6':
+    resolution: {integrity: sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.2.3':
-    resolution: {integrity: sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==}
+  '@next/swc-linux-arm64-gnu@16.2.6':
+    resolution: {integrity: sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@16.2.3':
-    resolution: {integrity: sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==}
+  '@next/swc-linux-arm64-musl@16.2.6':
+    resolution: {integrity: sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-gnu@16.2.3':
-    resolution: {integrity: sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==}
+  '@next/swc-linux-x64-gnu@16.2.6':
+    resolution: {integrity: sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-musl@16.2.3':
-    resolution: {integrity: sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==}
+  '@next/swc-linux-x64-musl@16.2.6':
+    resolution: {integrity: sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@16.2.3':
-    resolution: {integrity: sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==}
+  '@next/swc-win32-arm64-msvc@16.2.6':
+    resolution: {integrity: sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.2.3':
-    resolution: {integrity: sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==}
+  '@next/swc-win32-x64-msvc@16.2.6':
+    resolution: {integrity: sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -2642,8 +2642,8 @@ packages:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
-  next@16.2.3:
-    resolution: {integrity: sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA==}
+  next@16.2.6:
+    resolution: {integrity: sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -3726,30 +3726,30 @@ snapshots:
       chevrotain: 10.5.0
       lilconfig: 2.1.0
 
-  '@next/env@16.2.3': {}
+  '@next/env@16.2.6': {}
 
-  '@next/swc-darwin-arm64@16.2.3':
+  '@next/swc-darwin-arm64@16.2.6':
     optional: true
 
-  '@next/swc-darwin-x64@16.2.3':
+  '@next/swc-darwin-x64@16.2.6':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.2.3':
+  '@next/swc-linux-arm64-gnu@16.2.6':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.2.3':
+  '@next/swc-linux-arm64-musl@16.2.6':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.2.3':
+  '@next/swc-linux-x64-gnu@16.2.6':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.2.3':
+  '@next/swc-linux-x64-musl@16.2.6':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.2.3':
+  '@next/swc-win32-arm64-msvc@16.2.6':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.2.3':
+  '@next/swc-win32-x64-msvc@16.2.6':
     optional: true
 
   '@noble/hashes@2.0.1': {}
@@ -5408,9 +5408,9 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  next@16.2.3(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  next@16.2.6(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
-      '@next/env': 16.2.3
+      '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.20
       caniuse-lite: 1.0.30001788
@@ -5419,14 +5419,14 @@ snapshots:
       react-dom: 19.2.0(react@19.2.0)
       styled-jsx: 5.1.6(react@19.2.0)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.3
-      '@next/swc-darwin-x64': 16.2.3
-      '@next/swc-linux-arm64-gnu': 16.2.3
-      '@next/swc-linux-arm64-musl': 16.2.3
-      '@next/swc-linux-x64-gnu': 16.2.3
-      '@next/swc-linux-x64-musl': 16.2.3
-      '@next/swc-win32-arm64-msvc': 16.2.3
-      '@next/swc-win32-x64-msvc': 16.2.3
+      '@next/swc-darwin-arm64': 16.2.6
+      '@next/swc-darwin-x64': 16.2.6
+      '@next/swc-linux-arm64-gnu': 16.2.6
+      '@next/swc-linux-arm64-musl': 16.2.6
+      '@next/swc-linux-x64-gnu': 16.2.6
+      '@next/swc-linux-x64-musl': 16.2.6
+      '@next/swc-win32-arm64-msvc': 16.2.6
+      '@next/swc-win32-x64-msvc': 16.2.6
       babel-plugin-react-compiler: 1.0.0
       sharp: 0.34.5
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,10 @@
-onlyBuiltDependencies:
-    - '@prisma/engines'
-    - better-sqlite3
-    - esbuild
-    - prisma
-    - sharp
-    - unrs-resolver
+packages:
+    - '.'
+
+allowBuilds:
+    '@prisma/engines': true
+    better-sqlite3: true
+    esbuild: true
+    prisma: true
+    sharp: true
+    unrs-resolver: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,8 @@
 packages:
     - '.'
 
+# pnpm 11 replaced onlyBuiltDependencies with allowBuilds.
+# Keep native/prisma build scripts explicit so strict dependency builds stay on.
 allowBuilds:
     '@prisma/engines': true
     better-sqlite3: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,4 +9,3 @@ allowBuilds:
     esbuild: true
     prisma: true
     sharp: true
-    unrs-resolver: true


### PR DESCRIPTION
## why

#78 exposed that the docker workflow was using whatever corepack resolved, while lint and test workflows separately requested pnpm 10. after adding a repo-level `packageManager`, the workflows failed because pnpm/action-setup saw two pnpm versions. upgrading to pnpm 11 also requires node 22, so leaving ci on node 20 would just move the failure.

## what changed

- made `packageManager` the single pnpm version source for github actions.
- upgraded docker and ci to pnpm 11.0.8 / node 22.
- migrated pnpm build-script approvals from `onlyBuiltDependencies` to pnpm 11's `allowBuilds` shape so prisma, better-sqlite3, esbuild, and sharp can build in fresh installs.

## risk

risk is limited to dependency installation and ci/runtime build plumbing. no application code or database behavior changed. the main boundary is fresh installs: if build-script approvals are wrong, docker or ci fails before runtime.

## verification

- `database_url='file:./prisma/dev.db' pnpm prisma generate`
- `pnpm lint` (0 errors; existing warnings only)
- `pnpm check-types`
- `docker build --no-cache --target deps -t syntharena-deps-pnpm11 .`
- `docker run ... node:22-bookworm-slim ... pnpm install --frozen-lockfile && database_url='file:./prisma/test.db' pnpm prisma generate && pnpm test:run` (289 passed)
- `docker build -t syntharena-pnpm11-ci .`

## follow-ups

local mac `pnpm test:run` still hits an opaque prisma 7 schema-engine error under this node/corepack setup, but the node 22 linux ci-equivalent container path passes. that looks local-platform-specific rather than a ci blocker.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ischemist/codesmith/syntharena/pr/79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Node.js runtime to version 22 in CI workflows.
  * Upgraded package manager to pnpm 11.0.8 (package manifest and Docker build updated).
  * Revised workspace build policy to the new format, explicitly allowing native/Prisma-related builds and removing one previously listed package from the built set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR resolves a version-conflict between CI workflows and Docker by making `packageManager` in `package.json` the single source of truth for pnpm, upgrading from pnpm 10 to 11.0.8 and Node.js from 20 to 22 across all environments.

- Both GitHub Actions workflows drop the explicit `version: 10` from `pnpm/action-setup@v4`, relying on `packageManager: \"pnpm@11.0.8\"` in `package.json` to supply the version automatically; Node.js is bumped to 22 to satisfy pnpm 11's requirements.
- The Dockerfile's `corepack prepare` is updated to `pnpm@11.0.8`; hardcoding here is intentional because the `COPY` of `package.json` occurs after that `RUN` layer, so corepack cannot read the field dynamically.
- `pnpm-workspace.yaml` migrates from `onlyBuiltDependencies` to pnpm 11's `allowBuilds` map format, adds an explicit `packages: ['.']` entry, and intentionally drops `unrs-resolver` (uses prebuilt binaries, verified clean in fresh Docker and CI runs).

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are scoped entirely to CI plumbing and dependency installation; no application code or database logic was touched.

All changes are infrastructure-level: pnpm and Node.js version pins, the workspace build-script allowlist format, and a patch bump of Next.js. The author verified the full install-and-build path in a fresh Docker container and confirmed 289 tests pass on Linux/Node 22. The only behavioral boundary is whether build-script approvals in pnpm-workspace.yaml are correct for fresh installs, and that was explicitly tested.

No files require special attention. The Dockerfile's hardcoded pnpm version and the packageManager field in package.json must stay in sync manually, but they are in sync at 11.0.8 in this PR.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/code-quality.yml | Node.js upgraded 20→22; explicit pnpm version removed so pnpm/action-setup@v4 reads from packageManager in package.json |
| .github/workflows/tests.yml | Same pattern as code-quality.yml: Node.js 20→22, pnpm version deferred to packageManager field |
| Dockerfile | corepack prepare bumped from pnpm@10.33.4 to pnpm@11.0.8; hardcoding is necessary because the COPY of package.json happens after this RUN layer |
| package.json | packageManager updated to pnpm@11.0.8 (now the single version source for CI), next bumped 16.2.3→16.2.6 |
| pnpm-lock.yaml | Lock file mechanically updated for the next 16.2.3→16.2.6 bump; all SWC optional deps updated consistently |
| pnpm-workspace.yaml | Migrated onlyBuiltDependencies→allowBuilds for pnpm 11; added packages:['.'] for workspace root; unrs-resolver intentionally dropped (prebuilt binaries, verified in CI) |

</details>

<sub>Reviews (2): Last reviewed commit: ["chore: bump next to 16.2.6"](https://github.com/ischemist/syntharena/commit/f1c9eb4b4194d09faa837ef256cf01d86adb73e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31266254)</sub>

<!-- /greptile_comment -->