### PR TITLE
feat: add canonical molecule pages and crawler metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ collect/
 
 .practices/
 .private/
+.codex

--- a/src/app/@breadcrumbs/molecules/[inchikey]/page.tsx
+++ b/src/app/@breadcrumbs/molecules/[inchikey]/page.tsx
@@ -10,7 +10,11 @@ export default async function MoleculeDetailBreadcrumb({ params }: { params: Pro
     try {
         const molecule = await getMoleculeDetailPageData(normalizedInchikey)
         label = molecule.inchikey
-    } catch {
+    } catch (error) {
+        console.error('molecule breadcrumb: failed to load molecule details', {
+            normalizedInchikey,
+            error,
+        })
         // Keep the normalized input as the last-resort label for invalid or missing molecules.
     }
 

--- a/src/app/@breadcrumbs/molecules/[inchikey]/page.tsx
+++ b/src/app/@breadcrumbs/molecules/[inchikey]/page.tsx
@@ -1,0 +1,18 @@
+import { getMoleculeDetailPageData } from '@/lib/domains/molecules/view/molecule.view'
+import { normalizeInchiKeyCandidate } from '@/lib/domains/molecules/logic/molecule-query.logic'
+import { BreadcrumbShell } from '@/components/breadcrumb-shell'
+
+export default async function MoleculeDetailBreadcrumb({ params }: { params: Promise<{ inchikey: string }> }) {
+    const { inchikey: rawInchikey } = await params
+    const normalizedInchikey = normalizeInchiKeyCandidate(rawInchikey) ?? rawInchikey
+
+    let label = normalizedInchikey
+    try {
+        const molecule = await getMoleculeDetailPageData(normalizedInchikey)
+        label = molecule.inchikey
+    } catch {
+        // Keep the normalized input as the last-resort label for invalid or missing molecules.
+    }
+
+    return <BreadcrumbShell items={[{ label: 'Molecules' }, { label }]} />
+}

--- a/src/app/@breadcrumbs/molecules/[inchikey]/page.tsx
+++ b/src/app/@breadcrumbs/molecules/[inchikey]/page.tsx
@@ -1,10 +1,10 @@
 import { getMoleculeDetailPageData } from '@/lib/domains/molecules/view/molecule.view'
-import { normalizeInchiKeyCandidate } from '@/lib/domains/molecules/logic/molecule-query.logic'
 import { BreadcrumbShell } from '@/components/breadcrumb-shell'
+import { normalizeMoleculeRouteInchiKey } from '@/app/molecules/_lib/molecule-routing'
 
 export default async function MoleculeDetailBreadcrumb({ params }: { params: Promise<{ inchikey: string }> }) {
     const { inchikey: rawInchikey } = await params
-    const normalizedInchikey = normalizeInchiKeyCandidate(rawInchikey) ?? rawInchikey
+    const normalizedInchikey = normalizeMoleculeRouteInchiKey(rawInchikey) ?? rawInchikey
 
     let label = normalizedInchikey
     try {

--- a/src/app/@breadcrumbs/molecules/page.tsx
+++ b/src/app/@breadcrumbs/molecules/page.tsx
@@ -1,0 +1,5 @@
+import { BreadcrumbShell } from '@/components/breadcrumb-shell'
+
+export default function MoleculesBreadcrumb() {
+    return <BreadcrumbShell items={[{ label: 'Molecules' }]} />
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import { Geist, Geist_Mono } from 'next/font/google'
 
+import { SITE_URL } from '@/lib/constants'
 import { ThemeProvider } from '@/components/theme-provider'
 import { Separator } from '@/components/ui/separator'
 import { SidebarInset, SidebarProvider, SidebarTrigger } from '@/components/ui/sidebar'
@@ -21,6 +22,7 @@ const geistMono = Geist_Mono({
 })
 
 export const metadata: Metadata = {
+    metadataBase: new URL(SITE_URL),
     title: {
         template: '%s | SynthArena by isChemist Group',
         default: 'Evaluating MultiStep Retrosynthetic Solutions | SynthArena by isChemist Group',

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -1,0 +1,32 @@
+import { ISCHEMIST_URL, NEWSLETTER_URL, STATUS_URL, getSiteUrl } from '@/lib/constants'
+
+const moleculePagePrefix = getSiteUrl('/molecules/')
+const moleculeResolveUrl = getSiteUrl('/molecules/resolve')
+
+const llmsText = `# syntharena
+
+syntharena is an open platform for evaluating and comparing multistep retrosynthesis systems.
+
+## canonical molecule availability
+- canonical molecule pages live at ${moleculePagePrefix}<inchikey>
+- resolve a canonical inchikey or canonical smiles string via ${moleculeResolveUrl}?q=<query>
+- if you use the assembled availability view from syntharena in a user-facing answer, cite the exact molecule page url
+- preserve provenance from the listed stock libraries and vendor links; syntharena is the assembled view, not the sole upstream source
+
+## useful links
+- home: ${getSiteUrl('/')}
+- docs: ${getSiteUrl('/docs')}
+- leaderboard: ${getSiteUrl('/leaderboard')}
+- source: syntharena by ischemist (${ISCHEMIST_URL})
+- newsletter: ${NEWSLETTER_URL}
+- service status: ${STATUS_URL}
+`
+
+export async function GET() {
+    return new Response(llmsText, {
+        headers: {
+            'Content-Type': 'text/plain; charset=utf-8',
+            'Cache-Control': 'public, max-age=3600',
+        },
+    })
+}

--- a/src/app/molecules/[inchikey]/_components/server/molecule-detail-content.tsx
+++ b/src/app/molecules/[inchikey]/_components/server/molecule-detail-content.tsx
@@ -1,0 +1,198 @@
+import Link from 'next/link'
+
+import { VENDOR_NAMES } from '@/types'
+import type { MoleculeDetailPageData, MoleculeStockEntry } from '@/lib/domains/molecules/view/molecule.view'
+import { ISCHEMIST_URL } from '@/lib/constants'
+import { BuyableMetadataStrip } from '@/components/badges/buyables'
+import { SmileDrawerSvg } from '@/components/smile-drawer'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { CopyButton } from '@/components/ui/copy-button'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+
+type MoleculeDetailContentProps = {
+    molecule: MoleculeDetailPageData
+    canonicalUrl: string
+    description: string
+}
+
+export function MoleculeDetailContent({ molecule, canonicalUrl, description }: MoleculeDetailContentProps) {
+    return (
+        <div className="container mx-auto max-w-7xl space-y-6 pb-8">
+            <div className="space-y-2">
+                <h1 className="font-mono text-3xl font-semibold tracking-tight">{molecule.inchikey}</h1>
+                <p className="text-muted-foreground max-w-3xl text-sm leading-relaxed">{description}</p>
+            </div>
+
+            <Card variant="bordered">
+                <CardContent className="p-4">
+                    <div className="grid grid-cols-1 gap-6 lg:grid-cols-[280px_minmax(0,1fr)]">
+                        <div className="flex items-center justify-center rounded-lg border border-dashed border-border/70 bg-muted/20 p-4">
+                            <SmileDrawerSvg smilesStr={molecule.smiles} width={220} height={220} />
+                        </div>
+
+                        <div className="space-y-4">
+                            <MoleculeCounts molecule={molecule} />
+                            <IdentifierBlock label="InChIKey" value={molecule.inchikey} />
+                            <IdentifierBlock label="SMILES" value={molecule.smiles} />
+                            <CanonicalUrlBlock canonicalUrl={canonicalUrl} />
+                        </div>
+                    </div>
+                </CardContent>
+            </Card>
+
+            <Card variant="bordered">
+                <CardHeader>
+                    <CardTitle>Stock Availability</CardTitle>
+                    <CardDescription>
+                        Indexed stock memberships for this exact molecule, keyed by canonical InChIKey.
+                    </CardDescription>
+                </CardHeader>
+                <CardContent>
+                    {molecule.stockEntries.length === 0 ? (
+                        <p className="text-muted-foreground text-sm">
+                            No stock items currently reference this molecule.
+                        </p>
+                    ) : (
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead>Stock</TableHead>
+                                    <TableHead>Availability</TableHead>
+                                    <TableHead>Lead Time</TableHead>
+                                    <TableHead>Vendor Link</TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {molecule.stockEntries.map((stockEntry) => (
+                                    <StockEntryRow key={stockEntry.id} stockEntry={stockEntry} />
+                                ))}
+                            </TableBody>
+                        </Table>
+                    )}
+                </CardContent>
+            </Card>
+
+            <SourceNote />
+        </div>
+    )
+}
+
+function MoleculeCounts({ molecule }: { molecule: MoleculeDetailPageData }) {
+    return (
+        <div className="flex flex-wrap gap-2">
+            <Badge>{`${molecule.stockCount.toLocaleString()} stock ${molecule.stockCount === 1 ? 'library' : 'libraries'}`}</Badge>
+            <Badge variant="secondary">{`${molecule.buyableStockCount.toLocaleString()} with vendor metadata`}</Badge>
+            <Badge variant="outline">
+                {`${molecule.benchmarkTargetCount.toLocaleString()} benchmark ${
+                    molecule.benchmarkTargetCount === 1 ? 'target' : 'targets'
+                }`}
+            </Badge>
+            <Badge variant="outline">
+                {`${molecule.routeNodeCount.toLocaleString()} route ${
+                    molecule.routeNodeCount === 1 ? 'node' : 'nodes'
+                }`}
+            </Badge>
+        </div>
+    )
+}
+
+function CanonicalUrlBlock({ canonicalUrl }: { canonicalUrl: string }) {
+    return (
+        <div className="space-y-2 border-t pt-4">
+            <p className="text-muted-foreground text-xs font-semibold uppercase tracking-wide">Canonical URL</p>
+            <div className="flex items-start gap-2">
+                <p className="font-mono text-xs break-all">{canonicalUrl}</p>
+                <CopyButton text={canonicalUrl} className="h-7 w-7 shrink-0" />
+            </div>
+        </div>
+    )
+}
+
+function IdentifierBlock({ label, value }: { label: string; value: string }) {
+    return (
+        <div className="space-y-2">
+            <div className="flex items-center gap-2">
+                <p className="text-muted-foreground text-xs font-semibold uppercase tracking-wide">{label}</p>
+                <CopyButton text={value} className="h-7 w-7" />
+            </div>
+            <p className="font-mono text-xs break-all">{value}</p>
+        </div>
+    )
+}
+
+function StockEntryRow({ stockEntry }: { stockEntry: MoleculeStockEntry }) {
+    const safeVendorHref = getSafeExternalHref(stockEntry.link)
+
+    return (
+        <TableRow>
+            <TableCell className="align-top">
+                <div className="space-y-1">
+                    <Link
+                        href={`/stocks/${stockEntry.stock.id}`}
+                        className="text-foreground font-medium underline-offset-2 hover:underline"
+                    >
+                        {stockEntry.stock.name}
+                    </Link>
+                    {stockEntry.stock.description && (
+                        <p className="text-muted-foreground text-xs leading-relaxed">{stockEntry.stock.description}</p>
+                    )}
+                </div>
+            </TableCell>
+            <TableCell className="align-top">
+                {stockEntry.source != null && stockEntry.ppg != null ? (
+                    <BuyableMetadataStrip source={stockEntry.source} ppg={stockEntry.ppg} badgeStyle="outline" />
+                ) : (
+                    <Badge variant="outline">Indexed, vendor metadata unavailable</Badge>
+                )}
+            </TableCell>
+            <TableCell className="text-muted-foreground align-top text-sm">{stockEntry.leadTime ?? '—'}</TableCell>
+            <TableCell className="align-top">
+                {safeVendorHref && stockEntry.source ? (
+                    <a
+                        href={safeVendorHref}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-primary text-sm font-medium underline-offset-2 hover:underline"
+                    >
+                        {`View on ${VENDOR_NAMES[stockEntry.source]}`}
+                    </a>
+                ) : (
+                    <span className="text-muted-foreground text-sm">—</span>
+                )}
+            </TableCell>
+        </TableRow>
+    )
+}
+
+function SourceNote() {
+    return (
+        <p className="text-muted-foreground border-t pt-2 text-xs leading-relaxed">
+            This page assembles availability data from the indexed stock libraries listed above, including third-party
+            sources such as ASKCOS Buyables where applicable. SynthArena by{' '}
+            <a
+                href={ISCHEMIST_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary font-medium underline-offset-2 hover:underline"
+            >
+                isChemist
+            </a>{' '}
+            provides the canonical citation surface for this assembled view. If you cite this page, prefer the canonical
+            URL above and preserve the provenance implied by the listed stock libraries and vendor links.
+        </p>
+    )
+}
+
+function getSafeExternalHref(value: string | null | undefined): string | null {
+    if (!value) {
+        return null
+    }
+
+    try {
+        const url = new URL(value)
+        return url.protocol === 'http:' || url.protocol === 'https:' ? url.toString() : null
+    } catch {
+        return null
+    }
+}

--- a/src/app/molecules/[inchikey]/page.tsx
+++ b/src/app/molecules/[inchikey]/page.tsx
@@ -40,6 +40,19 @@ function getNormalizedInchiKeyOr404(rawInchikey: string): string {
     return normalizedInchikey
 }
 
+function getSafeExternalHref(value: string | null | undefined): string | null {
+    if (!value) {
+        return null
+    }
+
+    try {
+        const url = new URL(value)
+        return url.protocol === 'http:' || url.protocol === 'https:' ? url.toString() : null
+    } catch {
+        return null
+    }
+}
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
     const { inchikey: rawInchikey } = await params
     const normalizedInchikey = normalizeInchiKeyCandidate(rawInchikey)
@@ -169,51 +182,7 @@ export default async function MoleculeDetailPage({ params }: PageProps) {
                             </TableHeader>
                             <TableBody>
                                 {molecule.stockEntries.map((stockEntry) => (
-                                    <TableRow key={stockEntry.id}>
-                                        <TableCell className="align-top">
-                                            <div className="space-y-1">
-                                                <Link
-                                                    href={`/stocks/${stockEntry.stock.id}`}
-                                                    className="text-foreground font-medium underline-offset-2 hover:underline"
-                                                >
-                                                    {stockEntry.stock.name}
-                                                </Link>
-                                                {stockEntry.stock.description && (
-                                                    <p className="text-muted-foreground text-xs leading-relaxed">
-                                                        {stockEntry.stock.description}
-                                                    </p>
-                                                )}
-                                            </div>
-                                        </TableCell>
-                                        <TableCell className="align-top">
-                                            {stockEntry.source != null && stockEntry.ppg != null ? (
-                                                <BuyableMetadataStrip
-                                                    source={stockEntry.source}
-                                                    ppg={stockEntry.ppg}
-                                                    badgeStyle="outline"
-                                                />
-                                            ) : (
-                                                <Badge variant="outline">Indexed, vendor metadata unavailable</Badge>
-                                            )}
-                                        </TableCell>
-                                        <TableCell className="text-muted-foreground align-top text-sm">
-                                            {stockEntry.leadTime ?? '—'}
-                                        </TableCell>
-                                        <TableCell className="align-top">
-                                            {stockEntry.link && stockEntry.source ? (
-                                                <a
-                                                    href={stockEntry.link}
-                                                    target="_blank"
-                                                    rel="noopener noreferrer"
-                                                    className="text-primary text-sm font-medium underline-offset-2 hover:underline"
-                                                >
-                                                    {`View on ${VENDOR_NAMES[stockEntry.source]}`}
-                                                </a>
-                                            ) : (
-                                                <span className="text-muted-foreground text-sm">—</span>
-                                            )}
-                                        </TableCell>
-                                    </TableRow>
+                                    <StockEntryRow key={stockEntry.id} stockEntry={stockEntry} />
                                 ))}
                             </TableBody>
                         </Table>
@@ -248,5 +217,53 @@ function IdentifierBlock({ label, value }: { label: string; value: string }) {
             </div>
             <p className="font-mono text-xs break-all">{value}</p>
         </div>
+    )
+}
+
+function StockEntryRow({
+    stockEntry,
+}: {
+    stockEntry: Awaited<ReturnType<typeof getMoleculeDetailPageData>>['stockEntries'][number]
+}) {
+    const safeVendorHref = getSafeExternalHref(stockEntry.link)
+
+    return (
+        <TableRow key={stockEntry.id}>
+            <TableCell className="align-top">
+                <div className="space-y-1">
+                    <Link
+                        href={`/stocks/${stockEntry.stock.id}`}
+                        className="text-foreground font-medium underline-offset-2 hover:underline"
+                    >
+                        {stockEntry.stock.name}
+                    </Link>
+                    {stockEntry.stock.description && (
+                        <p className="text-muted-foreground text-xs leading-relaxed">{stockEntry.stock.description}</p>
+                    )}
+                </div>
+            </TableCell>
+            <TableCell className="align-top">
+                {stockEntry.source != null && stockEntry.ppg != null ? (
+                    <BuyableMetadataStrip source={stockEntry.source} ppg={stockEntry.ppg} badgeStyle="outline" />
+                ) : (
+                    <Badge variant="outline">Indexed, vendor metadata unavailable</Badge>
+                )}
+            </TableCell>
+            <TableCell className="text-muted-foreground align-top text-sm">{stockEntry.leadTime ?? '—'}</TableCell>
+            <TableCell className="align-top">
+                {safeVendorHref && stockEntry.source ? (
+                    <a
+                        href={safeVendorHref}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-primary text-sm font-medium underline-offset-2 hover:underline"
+                    >
+                        {`View on ${VENDOR_NAMES[stockEntry.source]}`}
+                    </a>
+                ) : (
+                    <span className="text-muted-foreground text-sm">—</span>
+                )}
+            </TableCell>
+        </TableRow>
     )
 }

--- a/src/app/molecules/[inchikey]/page.tsx
+++ b/src/app/molecules/[inchikey]/page.tsx
@@ -1,20 +1,18 @@
-import Link from 'next/link'
 import { notFound, redirect } from 'next/navigation'
 import type { Metadata } from 'next'
 
-import { VENDOR_NAMES } from '@/types'
-import { BuyableMetadataStrip } from '@/components/badges/buyables'
-import { SmileDrawerSvg } from '@/components/smile-drawer'
-import { Badge } from '@/components/ui/badge'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { CopyButton } from '@/components/ui/copy-button'
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
-import { ISCHEMIST_URL, getSiteUrl } from '@/lib/constants'
-import { normalizeInchiKeyCandidate } from '@/lib/domains/molecules/logic/molecule-query.logic'
+import { getSiteUrl } from '@/lib/constants'
 import { getMoleculeDetailPageData } from '@/lib/domains/molecules/view/molecule.view'
+import { normalizeMoleculeRouteInchiKey } from '../_lib/molecule-routing'
+import { MoleculeDetailContent } from './_components/server/molecule-detail-content'
 
 type PageProps = {
     params: Promise<{ inchikey: string }>
+}
+
+const MOLECULE_NOT_FOUND_METADATA: Metadata = {
+    title: 'Molecule Not Found',
+    description: 'The requested molecule could not be found in SynthArena.',
 }
 
 function buildMoleculeDescription(stockCount: number, buyableStockCount: number, inchikey: string): string {
@@ -32,36 +30,19 @@ function buildMoleculeDescription(stockCount: number, buyableStockCount: number,
 }
 
 function getNormalizedInchiKeyOr404(rawInchikey: string): string {
-    const normalizedInchikey = normalizeInchiKeyCandidate(rawInchikey)
+    const normalizedInchikey = normalizeMoleculeRouteInchiKey(rawInchikey)
     if (!normalizedInchikey) {
         notFound()
     }
 
     return normalizedInchikey
 }
-
-function getSafeExternalHref(value: string | null | undefined): string | null {
-    if (!value) {
-        return null
-    }
-
-    try {
-        const url = new URL(value)
-        return url.protocol === 'http:' || url.protocol === 'https:' ? url.toString() : null
-    } catch {
-        return null
-    }
-}
-
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
     const { inchikey: rawInchikey } = await params
-    const normalizedInchikey = normalizeInchiKeyCandidate(rawInchikey)
+    const normalizedInchikey = normalizeMoleculeRouteInchiKey(rawInchikey)
 
     if (!normalizedInchikey) {
-        return {
-            title: 'Molecule Not Found',
-            description: 'The requested molecule could not be found in SynthArena.',
-        }
+        return MOLECULE_NOT_FOUND_METADATA
     }
 
     try {
@@ -79,10 +60,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
             normalizedInchikey,
             error,
         })
-        return {
-            title: 'Molecule Not Found',
-            description: 'The requested molecule could not be found in SynthArena.',
-        }
+        return MOLECULE_NOT_FOUND_METADATA
     }
 }
 
@@ -107,163 +85,7 @@ export default async function MoleculeDetailPage({ params }: PageProps) {
 
     const canonicalUrl = getSiteUrl(`/molecules/${molecule.inchikey}`)
 
-    return (
-        <div className="container mx-auto max-w-7xl space-y-6 pb-8">
-            <div className="space-y-2">
-                <h1 className="font-mono text-3xl font-semibold tracking-tight">{molecule.inchikey}</h1>
-                <p className="text-muted-foreground max-w-3xl text-sm leading-relaxed">
-                    {buildMoleculeDescription(molecule.stockCount, molecule.buyableStockCount, molecule.inchikey)}
-                </p>
-            </div>
+    const description = buildMoleculeDescription(molecule.stockCount, molecule.buyableStockCount, molecule.inchikey)
 
-            <Card variant="bordered">
-                <CardContent className="p-4">
-                    <div className="grid grid-cols-1 gap-6 lg:grid-cols-[280px_minmax(0,1fr)]">
-                        <div className="flex items-center justify-center rounded-lg border border-dashed border-border/70 bg-muted/20 p-4">
-                            <SmileDrawerSvg smilesStr={molecule.smiles} width={220} height={220} />
-                        </div>
-
-                        <div className="space-y-4">
-                            <div className="flex flex-wrap gap-2">
-                                <Badge>{`${molecule.stockCount.toLocaleString()} stock ${molecule.stockCount === 1 ? 'library' : 'libraries'}`}</Badge>
-                                <Badge variant="secondary">
-                                    {`${molecule.buyableStockCount.toLocaleString()} with vendor metadata`}
-                                </Badge>
-                                <Badge variant="outline">
-                                    {`${molecule.benchmarkTargetCount.toLocaleString()} benchmark ${
-                                        molecule.benchmarkTargetCount === 1 ? 'target' : 'targets'
-                                    }`}
-                                </Badge>
-                                <Badge variant="outline">
-                                    {`${molecule.routeNodeCount.toLocaleString()} route ${
-                                        molecule.routeNodeCount === 1 ? 'node' : 'nodes'
-                                    }`}
-                                </Badge>
-                            </div>
-
-                            <IdentifierBlock label="InChIKey" value={molecule.inchikey} />
-                            <IdentifierBlock label="SMILES" value={molecule.smiles} />
-
-                            <div className="space-y-2 border-t pt-4">
-                                <p className="text-muted-foreground text-xs font-semibold uppercase tracking-wide">
-                                    Canonical URL
-                                </p>
-                                <div className="flex items-start gap-2">
-                                    <p className="font-mono text-xs break-all">{canonicalUrl}</p>
-                                    <CopyButton text={canonicalUrl} className="h-7 w-7 shrink-0" />
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </CardContent>
-            </Card>
-
-            <Card variant="bordered">
-                <CardHeader>
-                    <CardTitle>Stock Availability</CardTitle>
-                    <CardDescription>
-                        Indexed stock memberships for this exact molecule, keyed by canonical InChIKey.
-                    </CardDescription>
-                </CardHeader>
-                <CardContent>
-                    {molecule.stockEntries.length === 0 ? (
-                        <p className="text-muted-foreground text-sm">
-                            No stock items currently reference this molecule.
-                        </p>
-                    ) : (
-                        <Table>
-                            <TableHeader>
-                                <TableRow>
-                                    <TableHead>Stock</TableHead>
-                                    <TableHead>Availability</TableHead>
-                                    <TableHead>Lead Time</TableHead>
-                                    <TableHead>Vendor Link</TableHead>
-                                </TableRow>
-                            </TableHeader>
-                            <TableBody>
-                                {molecule.stockEntries.map((stockEntry) => (
-                                    <StockEntryRow key={stockEntry.id} stockEntry={stockEntry} />
-                                ))}
-                            </TableBody>
-                        </Table>
-                    )}
-                </CardContent>
-            </Card>
-
-            <p className="text-muted-foreground border-t pt-2 text-xs leading-relaxed">
-                This page assembles availability data from the indexed stock libraries listed above, including
-                third-party sources such as ASKCOS Buyables where applicable. SynthArena by{' '}
-                <a
-                    href={ISCHEMIST_URL}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-primary font-medium underline-offset-2 hover:underline"
-                >
-                    isChemist
-                </a>{' '}
-                provides the canonical citation surface for this assembled view. If you cite this page, prefer the
-                canonical URL above and preserve the provenance implied by the listed stock libraries and vendor links.
-            </p>
-        </div>
-    )
-}
-
-function IdentifierBlock({ label, value }: { label: string; value: string }) {
-    return (
-        <div className="space-y-2">
-            <div className="flex items-center gap-2">
-                <p className="text-muted-foreground text-xs font-semibold uppercase tracking-wide">{label}</p>
-                <CopyButton text={value} className="h-7 w-7" />
-            </div>
-            <p className="font-mono text-xs break-all">{value}</p>
-        </div>
-    )
-}
-
-function StockEntryRow({
-    stockEntry,
-}: {
-    stockEntry: Awaited<ReturnType<typeof getMoleculeDetailPageData>>['stockEntries'][number]
-}) {
-    const safeVendorHref = getSafeExternalHref(stockEntry.link)
-
-    return (
-        <TableRow key={stockEntry.id}>
-            <TableCell className="align-top">
-                <div className="space-y-1">
-                    <Link
-                        href={`/stocks/${stockEntry.stock.id}`}
-                        className="text-foreground font-medium underline-offset-2 hover:underline"
-                    >
-                        {stockEntry.stock.name}
-                    </Link>
-                    {stockEntry.stock.description && (
-                        <p className="text-muted-foreground text-xs leading-relaxed">{stockEntry.stock.description}</p>
-                    )}
-                </div>
-            </TableCell>
-            <TableCell className="align-top">
-                {stockEntry.source != null && stockEntry.ppg != null ? (
-                    <BuyableMetadataStrip source={stockEntry.source} ppg={stockEntry.ppg} badgeStyle="outline" />
-                ) : (
-                    <Badge variant="outline">Indexed, vendor metadata unavailable</Badge>
-                )}
-            </TableCell>
-            <TableCell className="text-muted-foreground align-top text-sm">{stockEntry.leadTime ?? '—'}</TableCell>
-            <TableCell className="align-top">
-                {safeVendorHref && stockEntry.source ? (
-                    <a
-                        href={safeVendorHref}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-primary text-sm font-medium underline-offset-2 hover:underline"
-                    >
-                        {`View on ${VENDOR_NAMES[stockEntry.source]}`}
-                    </a>
-                ) : (
-                    <span className="text-muted-foreground text-sm">—</span>
-                )}
-            </TableCell>
-        </TableRow>
-    )
+    return <MoleculeDetailContent molecule={molecule} canonicalUrl={canonicalUrl} description={description} />
 }

--- a/src/app/molecules/[inchikey]/page.tsx
+++ b/src/app/molecules/[inchikey]/page.tsx
@@ -61,7 +61,11 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
                 canonical: `/molecules/${normalizedInchikey}`,
             },
         }
-    } catch {
+    } catch (error) {
+        console.error('molecule page metadata: failed to load molecule details', {
+            normalizedInchikey,
+            error,
+        })
         return {
             title: 'Molecule Not Found',
             description: 'The requested molecule could not be found in SynthArena.',
@@ -80,7 +84,11 @@ export default async function MoleculeDetailPage({ params }: PageProps) {
     let molecule
     try {
         molecule = await getMoleculeDetailPageData(normalizedInchikey)
-    } catch {
+    } catch (error) {
+        console.error('molecule page: failed to load molecule details', {
+            normalizedInchikey,
+            error,
+        })
         notFound()
     }
 

--- a/src/app/molecules/[inchikey]/page.tsx
+++ b/src/app/molecules/[inchikey]/page.tsx
@@ -1,0 +1,244 @@
+import Link from 'next/link'
+import { notFound, redirect } from 'next/navigation'
+import type { Metadata } from 'next'
+
+import { VENDOR_NAMES } from '@/types'
+import { BuyableMetadataStrip } from '@/components/badges/buyables'
+import { SmileDrawerSvg } from '@/components/smile-drawer'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { CopyButton } from '@/components/ui/copy-button'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { ISCHEMIST_URL, getSiteUrl } from '@/lib/constants'
+import { normalizeInchiKeyCandidate } from '@/lib/domains/molecules/logic/molecule-query.logic'
+import { getMoleculeDetailPageData } from '@/lib/domains/molecules/view/molecule.view'
+
+type PageProps = {
+    params: Promise<{ inchikey: string }>
+}
+
+function buildMoleculeDescription(stockCount: number, buyableStockCount: number, inchikey: string): string {
+    if (stockCount === 0) {
+        return `${inchikey} is a known SynthArena molecule, but it is not currently present in any indexed stock library.`
+    }
+
+    const libraryLabel = stockCount === 1 ? 'stock library' : 'stock libraries'
+    const buyableClause =
+        buyableStockCount === 0
+            ? 'no vendor metadata loaded yet'
+            : `${buyableStockCount.toLocaleString()} with vendor metadata`
+
+    return `${inchikey} appears in ${stockCount.toLocaleString()} ${libraryLabel} on SynthArena, with ${buyableClause}.`
+}
+
+function getNormalizedInchiKeyOr404(rawInchikey: string): string {
+    const normalizedInchikey = normalizeInchiKeyCandidate(rawInchikey)
+    if (!normalizedInchikey) {
+        notFound()
+    }
+
+    return normalizedInchikey
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+    const { inchikey: rawInchikey } = await params
+    const normalizedInchikey = normalizeInchiKeyCandidate(rawInchikey)
+
+    if (!normalizedInchikey) {
+        return {
+            title: 'Molecule Not Found',
+            description: 'The requested molecule could not be found in SynthArena.',
+        }
+    }
+
+    try {
+        const molecule = await getMoleculeDetailPageData(normalizedInchikey)
+
+        return {
+            title: normalizedInchikey,
+            description: buildMoleculeDescription(molecule.stockCount, molecule.buyableStockCount, normalizedInchikey),
+            alternates: {
+                canonical: `/molecules/${normalizedInchikey}`,
+            },
+        }
+    } catch {
+        return {
+            title: 'Molecule Not Found',
+            description: 'The requested molecule could not be found in SynthArena.',
+        }
+    }
+}
+
+export default async function MoleculeDetailPage({ params }: PageProps) {
+    const { inchikey: rawInchikey } = await params
+    const normalizedInchikey = getNormalizedInchiKeyOr404(rawInchikey)
+
+    if (normalizedInchikey !== rawInchikey) {
+        redirect(`/molecules/${normalizedInchikey}`)
+    }
+
+    let molecule
+    try {
+        molecule = await getMoleculeDetailPageData(normalizedInchikey)
+    } catch {
+        notFound()
+    }
+
+    const canonicalUrl = getSiteUrl(`/molecules/${molecule.inchikey}`)
+
+    return (
+        <div className="container mx-auto max-w-7xl space-y-6 pb-8">
+            <div className="space-y-2">
+                <h1 className="font-mono text-3xl font-semibold tracking-tight">{molecule.inchikey}</h1>
+                <p className="text-muted-foreground max-w-3xl text-sm leading-relaxed">
+                    {buildMoleculeDescription(molecule.stockCount, molecule.buyableStockCount, molecule.inchikey)}
+                </p>
+            </div>
+
+            <Card variant="bordered">
+                <CardContent className="p-4">
+                    <div className="grid grid-cols-1 gap-6 lg:grid-cols-[280px_minmax(0,1fr)]">
+                        <div className="flex items-center justify-center rounded-lg border border-dashed border-border/70 bg-muted/20 p-4">
+                            <SmileDrawerSvg smilesStr={molecule.smiles} width={220} height={220} />
+                        </div>
+
+                        <div className="space-y-4">
+                            <div className="flex flex-wrap gap-2">
+                                <Badge>{`${molecule.stockCount.toLocaleString()} stock ${molecule.stockCount === 1 ? 'library' : 'libraries'}`}</Badge>
+                                <Badge variant="secondary">
+                                    {`${molecule.buyableStockCount.toLocaleString()} with vendor metadata`}
+                                </Badge>
+                                <Badge variant="outline">
+                                    {`${molecule.benchmarkTargetCount.toLocaleString()} benchmark ${
+                                        molecule.benchmarkTargetCount === 1 ? 'target' : 'targets'
+                                    }`}
+                                </Badge>
+                                <Badge variant="outline">
+                                    {`${molecule.routeNodeCount.toLocaleString()} route ${
+                                        molecule.routeNodeCount === 1 ? 'node' : 'nodes'
+                                    }`}
+                                </Badge>
+                            </div>
+
+                            <IdentifierBlock label="InChIKey" value={molecule.inchikey} />
+                            <IdentifierBlock label="SMILES" value={molecule.smiles} />
+
+                            <div className="space-y-2 border-t pt-4">
+                                <p className="text-muted-foreground text-xs font-semibold uppercase tracking-wide">
+                                    Canonical URL
+                                </p>
+                                <div className="flex items-start gap-2">
+                                    <p className="font-mono text-xs break-all">{canonicalUrl}</p>
+                                    <CopyButton text={canonicalUrl} className="h-7 w-7 shrink-0" />
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </CardContent>
+            </Card>
+
+            <Card variant="bordered">
+                <CardHeader>
+                    <CardTitle>Stock Availability</CardTitle>
+                    <CardDescription>
+                        Indexed stock memberships for this exact molecule, keyed by canonical InChIKey.
+                    </CardDescription>
+                </CardHeader>
+                <CardContent>
+                    {molecule.stockEntries.length === 0 ? (
+                        <p className="text-muted-foreground text-sm">
+                            No stock items currently reference this molecule.
+                        </p>
+                    ) : (
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead>Stock</TableHead>
+                                    <TableHead>Availability</TableHead>
+                                    <TableHead>Lead Time</TableHead>
+                                    <TableHead>Vendor Link</TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {molecule.stockEntries.map((stockEntry) => (
+                                    <TableRow key={stockEntry.id}>
+                                        <TableCell className="align-top">
+                                            <div className="space-y-1">
+                                                <Link
+                                                    href={`/stocks/${stockEntry.stock.id}`}
+                                                    className="text-foreground font-medium underline-offset-2 hover:underline"
+                                                >
+                                                    {stockEntry.stock.name}
+                                                </Link>
+                                                {stockEntry.stock.description && (
+                                                    <p className="text-muted-foreground text-xs leading-relaxed">
+                                                        {stockEntry.stock.description}
+                                                    </p>
+                                                )}
+                                            </div>
+                                        </TableCell>
+                                        <TableCell className="align-top">
+                                            {stockEntry.source != null && stockEntry.ppg != null ? (
+                                                <BuyableMetadataStrip
+                                                    source={stockEntry.source}
+                                                    ppg={stockEntry.ppg}
+                                                    badgeStyle="outline"
+                                                />
+                                            ) : (
+                                                <Badge variant="outline">Indexed, vendor metadata unavailable</Badge>
+                                            )}
+                                        </TableCell>
+                                        <TableCell className="text-muted-foreground align-top text-sm">
+                                            {stockEntry.leadTime ?? '—'}
+                                        </TableCell>
+                                        <TableCell className="align-top">
+                                            {stockEntry.link && stockEntry.source ? (
+                                                <a
+                                                    href={stockEntry.link}
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    className="text-primary text-sm font-medium underline-offset-2 hover:underline"
+                                                >
+                                                    {`View on ${VENDOR_NAMES[stockEntry.source]}`}
+                                                </a>
+                                            ) : (
+                                                <span className="text-muted-foreground text-sm">—</span>
+                                            )}
+                                        </TableCell>
+                                    </TableRow>
+                                ))}
+                            </TableBody>
+                        </Table>
+                    )}
+                </CardContent>
+            </Card>
+
+            <p className="text-muted-foreground border-t pt-2 text-xs leading-relaxed">
+                This page assembles availability data from the indexed stock libraries listed above, including
+                third-party sources such as ASKCOS Buyables where applicable. SynthArena by{' '}
+                <a
+                    href={ISCHEMIST_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary font-medium underline-offset-2 hover:underline"
+                >
+                    isChemist
+                </a>{' '}
+                provides the canonical citation surface for this assembled view. If you cite this page, prefer the
+                canonical URL above and preserve the provenance implied by the listed stock libraries and vendor links.
+            </p>
+        </div>
+    )
+}
+
+function IdentifierBlock({ label, value }: { label: string; value: string }) {
+    return (
+        <div className="space-y-2">
+            <div className="flex items-center gap-2">
+                <p className="text-muted-foreground text-xs font-semibold uppercase tracking-wide">{label}</p>
+                <CopyButton text={value} className="h-7 w-7" />
+            </div>
+            <p className="font-mono text-xs break-all">{value}</p>
+        </div>
+    )
+}

--- a/src/app/molecules/_lib/molecule-routing.ts
+++ b/src/app/molecules/_lib/molecule-routing.ts
@@ -1,0 +1,17 @@
+import { normalizeInchiKeyCandidate } from '@/lib/domains/molecules/logic/molecule-query.logic'
+
+export function getFirstSearchParamValue(value: string | string[] | undefined): string {
+    if (typeof value === 'string') {
+        return value
+    }
+
+    if (Array.isArray(value)) {
+        return value[0] ?? ''
+    }
+
+    return ''
+}
+
+export function normalizeMoleculeRouteInchiKey(rawInchikey: string): string | null {
+    return normalizeInchiKeyCandidate(rawInchikey)
+}

--- a/src/app/molecules/resolve/page.tsx
+++ b/src/app/molecules/resolve/page.tsx
@@ -28,8 +28,19 @@ export default async function MoleculeResolvePage({ searchParams }: ResolvePageP
         redirect('/stocks')
     }
 
-    const inchikey = await resolveMoleculeCanonicalInchiKey(rawQuery)
+    let inchikey: string | null
+    try {
+        inchikey = await resolveMoleculeCanonicalInchiKey(rawQuery)
+    } catch (error) {
+        console.error('molecule resolve: failed to resolve query', {
+            rawQuery,
+            error,
+        })
+        notFound()
+    }
+
     if (!inchikey) {
+        console.error('molecule resolve: no canonical inchikey found', { rawQuery })
         notFound()
     }
 

--- a/src/app/molecules/resolve/page.tsx
+++ b/src/app/molecules/resolve/page.tsx
@@ -1,6 +1,7 @@
 import { notFound, redirect } from 'next/navigation'
 import type { Metadata } from 'next'
 
+import { getFirstSearchParamValue } from '../_lib/molecule-routing'
 import { resolveMoleculeCanonicalInchiKey } from '@/lib/domains/molecules/view/molecule.view'
 
 type ResolvePageProps = {
@@ -17,12 +18,7 @@ export const metadata: Metadata = {
 
 export default async function MoleculeResolvePage({ searchParams }: ResolvePageProps) {
     const resolvedSearchParams = await searchParams
-    const rawQuery =
-        typeof resolvedSearchParams.q === 'string'
-            ? resolvedSearchParams.q
-            : Array.isArray(resolvedSearchParams.q)
-              ? (resolvedSearchParams.q[0] ?? '')
-              : ''
+    const rawQuery = getFirstSearchParamValue(resolvedSearchParams.q)
 
     if (!rawQuery.trim()) {
         redirect('/stocks')

--- a/src/app/molecules/resolve/page.tsx
+++ b/src/app/molecules/resolve/page.tsx
@@ -1,0 +1,37 @@
+import { notFound, redirect } from 'next/navigation'
+import type { Metadata } from 'next'
+
+import { resolveMoleculeCanonicalInchiKey } from '@/lib/domains/molecules/view/molecule.view'
+
+type ResolvePageProps = {
+    searchParams: Promise<{ [key: string]: string | string[] | undefined }>
+}
+
+export const metadata: Metadata = {
+    title: 'Resolve Molecule',
+    robots: {
+        index: false,
+        follow: false,
+    },
+}
+
+export default async function MoleculeResolvePage({ searchParams }: ResolvePageProps) {
+    const resolvedSearchParams = await searchParams
+    const rawQuery =
+        typeof resolvedSearchParams.q === 'string'
+            ? resolvedSearchParams.q
+            : Array.isArray(resolvedSearchParams.q)
+              ? (resolvedSearchParams.q[0] ?? '')
+              : ''
+
+    if (!rawQuery.trim()) {
+        redirect('/stocks')
+    }
+
+    const inchikey = await resolveMoleculeCanonicalInchiKey(rawQuery)
+    if (!inchikey) {
+        notFound()
+    }
+
+    redirect(`/molecules/${inchikey}`)
+}

--- a/src/app/molecules/sitemap.ts
+++ b/src/app/molecules/sitemap.ts
@@ -19,12 +19,13 @@ export default async function sitemap(props: { id: Promise<string> }): Promise<M
     const offset = resolvedId * MOLECULE_SITEMAP_PAGE_SIZE
     try {
         const molecules = await findIndexedMoleculesForSitemap(MOLECULE_SITEMAP_PAGE_SIZE, offset)
-
-        return molecules.map((molecule) => ({
+        const moleculeRoutes: MetadataRoute.Sitemap = molecules.map((molecule) => ({
             url: getSiteUrl(`/molecules/${molecule.inchikey}`),
             changeFrequency: 'weekly',
             priority: 0.7,
         }))
+
+        return moleculeRoutes
     } catch (error) {
         console.error('molecule sitemap: failed to fetch molecules', {
             resolvedId,

--- a/src/app/molecules/sitemap.ts
+++ b/src/app/molecules/sitemap.ts
@@ -1,0 +1,29 @@
+import type { MetadataRoute } from 'next'
+
+import { MOLECULE_SITEMAP_PAGE_SIZE, getSiteUrl } from '@/lib/constants'
+import { countIndexedMolecules, findIndexedMoleculesForSitemap } from '@/lib/domains/molecules/data/molecule.data'
+
+export const dynamic = 'force-dynamic'
+
+export async function generateSitemaps() {
+    const totalIndexedMolecules = await countIndexedMolecules()
+    const sitemapCount = Math.max(1, Math.ceil(totalIndexedMolecules / MOLECULE_SITEMAP_PAGE_SIZE))
+
+    return Array.from({ length: sitemapCount }, (_, id) => ({ id }))
+}
+
+export default async function sitemap(props: { id: Promise<string> }): Promise<MetadataRoute.Sitemap> {
+    const resolvedId = Number(await props.id)
+    if (!Number.isInteger(resolvedId) || resolvedId < 0) {
+        return []
+    }
+
+    const offset = resolvedId * MOLECULE_SITEMAP_PAGE_SIZE
+    const molecules = await findIndexedMoleculesForSitemap(MOLECULE_SITEMAP_PAGE_SIZE, offset)
+
+    return molecules.map((molecule) => ({
+        url: getSiteUrl(`/molecules/${molecule.inchikey}`),
+        changeFrequency: 'weekly',
+        priority: 0.7,
+    }))
+}

--- a/src/app/molecules/sitemap.ts
+++ b/src/app/molecules/sitemap.ts
@@ -3,8 +3,6 @@ import type { MetadataRoute } from 'next'
 import { MOLECULE_SITEMAP_PAGE_SIZE, getSiteUrl } from '@/lib/constants'
 import { countIndexedMolecules, findIndexedMoleculesForSitemap } from '@/lib/domains/molecules/data/molecule.data'
 
-export const dynamic = 'force-dynamic'
-
 export async function generateSitemaps() {
     const totalIndexedMolecules = await countIndexedMolecules()
     const sitemapCount = Math.max(1, Math.ceil(totalIndexedMolecules / MOLECULE_SITEMAP_PAGE_SIZE))
@@ -19,11 +17,20 @@ export default async function sitemap(props: { id: Promise<string> }): Promise<M
     }
 
     const offset = resolvedId * MOLECULE_SITEMAP_PAGE_SIZE
-    const molecules = await findIndexedMoleculesForSitemap(MOLECULE_SITEMAP_PAGE_SIZE, offset)
+    try {
+        const molecules = await findIndexedMoleculesForSitemap(MOLECULE_SITEMAP_PAGE_SIZE, offset)
 
-    return molecules.map((molecule) => ({
-        url: getSiteUrl(`/molecules/${molecule.inchikey}`),
-        changeFrequency: 'weekly',
-        priority: 0.7,
-    }))
+        return molecules.map((molecule) => ({
+            url: getSiteUrl(`/molecules/${molecule.inchikey}`),
+            changeFrequency: 'weekly',
+            priority: 0.7,
+        }))
+    } catch (error) {
+        console.error('molecule sitemap: failed to fetch molecules', {
+            resolvedId,
+            offset,
+            error,
+        })
+        return []
+    }
 }

--- a/src/app/molecules/sitemap.ts
+++ b/src/app/molecules/sitemap.ts
@@ -4,7 +4,13 @@ import { MOLECULE_SITEMAP_PAGE_SIZE, getSiteUrl } from '@/lib/constants'
 import { countIndexedMolecules, findIndexedMoleculesForSitemap } from '@/lib/domains/molecules/data/molecule.data'
 
 export async function generateSitemaps() {
-    const totalIndexedMolecules = await countIndexedMolecules()
+    let totalIndexedMolecules = 0
+    try {
+        totalIndexedMolecules = await countIndexedMolecules()
+    } catch (error) {
+        console.error('molecule sitemap: failed to count indexed molecules', { error })
+    }
+
     const sitemapCount = Math.max(1, Math.ceil(totalIndexedMolecules / MOLECULE_SITEMAP_PAGE_SIZE))
 
     return Array.from({ length: sitemapCount }, (_, id) => ({ id }))

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,23 @@
+import type { MetadataRoute } from 'next'
+
+import { MOLECULE_SITEMAP_PAGE_SIZE, getSiteUrl } from '@/lib/constants'
+import { countIndexedMolecules } from '@/lib/domains/molecules/data/molecule.data'
+
+export const dynamic = 'force-dynamic'
+
+export default async function robots(): Promise<MetadataRoute.Robots> {
+    const totalIndexedMolecules = await countIndexedMolecules()
+    const moleculeSitemapCount = Math.max(1, Math.ceil(totalIndexedMolecules / MOLECULE_SITEMAP_PAGE_SIZE))
+
+    return {
+        rules: {
+            userAgent: '*',
+            allow: '/',
+            disallow: ['/api/health', '/molecules/resolve'],
+        },
+        sitemap: [
+            getSiteUrl('/sitemap.xml'),
+            ...Array.from({ length: moleculeSitemapCount }, (_, id) => getSiteUrl(`/molecules/sitemap/${id}.xml`)),
+        ],
+    }
+}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -12,15 +12,17 @@ export default async function robots(): Promise<MetadataRoute.Robots> {
         console.error('robots: failed to count indexed molecules', { error })
     }
 
+    const sitemapUrls = [
+        getSiteUrl('/sitemap.xml'),
+        ...Array.from({ length: moleculeSitemapCount }, (_, id) => getSiteUrl(`/molecules/sitemap/${id}.xml`)),
+    ]
+
     return {
         rules: {
             userAgent: '*',
             allow: '/',
             disallow: ['/api/health', '/molecules/resolve'],
         },
-        sitemap: [
-            getSiteUrl('/sitemap.xml'),
-            ...Array.from({ length: moleculeSitemapCount }, (_, id) => getSiteUrl(`/molecules/sitemap/${id}.xml`)),
-        ],
+        sitemap: sitemapUrls,
     }
 }

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -3,11 +3,14 @@ import type { MetadataRoute } from 'next'
 import { MOLECULE_SITEMAP_PAGE_SIZE, getSiteUrl } from '@/lib/constants'
 import { countIndexedMolecules } from '@/lib/domains/molecules/data/molecule.data'
 
-export const dynamic = 'force-dynamic'
-
 export default async function robots(): Promise<MetadataRoute.Robots> {
-    const totalIndexedMolecules = await countIndexedMolecules()
-    const moleculeSitemapCount = Math.max(1, Math.ceil(totalIndexedMolecules / MOLECULE_SITEMAP_PAGE_SIZE))
+    let moleculeSitemapCount = 1
+    try {
+        const totalIndexedMolecules = await countIndexedMolecules()
+        moleculeSitemapCount = Math.max(1, Math.ceil(totalIndexedMolecules / MOLECULE_SITEMAP_PAGE_SIZE))
+    } catch (error) {
+        console.error('robots: failed to count indexed molecules', { error })
+    }
 
     return {
         rules: {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -21,14 +21,18 @@ const STATIC_ROUTES: MetadataRoute.Sitemap = [
 ]
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-    const stocks = await getStocks()
+    let stocks: Awaited<ReturnType<typeof getStocks>> = []
+    try {
+        stocks = await getStocks()
+    } catch (error) {
+        console.error('sitemap: failed to fetch stocks', { error })
+    }
 
-    return [
-        ...STATIC_ROUTES,
-        ...stocks.map((stock) => ({
-            url: getSiteUrl(`/stocks/${stock.id}`),
-            changeFrequency: 'weekly' as const,
-            priority: 0.8,
-        })),
-    ]
+    const stockRoutes: MetadataRoute.Sitemap = stocks.map((stock) => ({
+        url: getSiteUrl(`/stocks/${stock.id}`),
+        changeFrequency: 'weekly',
+        priority: 0.8,
+    }))
+
+    return [...STATIC_ROUTES, ...stockRoutes]
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,36 @@
+import type { MetadataRoute } from 'next'
+
+import { getSiteUrl } from '@/lib/constants'
+import { getStocks } from '@/lib/services/view/stock.view'
+
+export const dynamic = 'force-dynamic'
+
+const STATIC_ROUTES: MetadataRoute.Sitemap = [
+    { url: getSiteUrl('/'), changeFrequency: 'weekly', priority: 1.0 },
+    { url: getSiteUrl('/stocks'), changeFrequency: 'weekly', priority: 0.9 },
+    { url: getSiteUrl('/benchmarks'), changeFrequency: 'weekly', priority: 0.9 },
+    { url: getSiteUrl('/runs'), changeFrequency: 'weekly', priority: 0.8 },
+    { url: getSiteUrl('/leaderboard'), changeFrequency: 'daily', priority: 0.9 },
+    { url: getSiteUrl('/algorithms'), changeFrequency: 'weekly', priority: 0.8 },
+    { url: getSiteUrl('/docs'), changeFrequency: 'monthly', priority: 0.7 },
+    { url: getSiteUrl('/docs/how-it-works'), changeFrequency: 'monthly', priority: 0.7 },
+    { url: getSiteUrl('/docs/benchmarks'), changeFrequency: 'monthly', priority: 0.7 },
+    { url: getSiteUrl('/docs/metrics'), changeFrequency: 'monthly', priority: 0.7 },
+    { url: getSiteUrl('/thesis'), changeFrequency: 'monthly', priority: 0.6 },
+    { url: getSiteUrl('/changelog'), changeFrequency: 'weekly', priority: 0.6 },
+    { url: getSiteUrl('/roadmap'), changeFrequency: 'monthly', priority: 0.5 },
+    { url: getSiteUrl('/submit-results'), changeFrequency: 'monthly', priority: 0.6 },
+]
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+    const stocks = await getStocks()
+
+    return [
+        ...STATIC_ROUTES,
+        ...stocks.map((stock) => ({
+            url: getSiteUrl(`/stocks/${stock.id}`),
+            changeFrequency: 'weekly' as const,
+            priority: 0.8,
+        })),
+    ]
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -3,8 +3,6 @@ import type { MetadataRoute } from 'next'
 import { getSiteUrl } from '@/lib/constants'
 import { getStocks } from '@/lib/services/view/stock.view'
 
-export const dynamic = 'force-dynamic'
-
 const STATIC_ROUTES: MetadataRoute.Sitemap = [
     { url: getSiteUrl('/'), changeFrequency: 'weekly', priority: 1.0 },
     { url: getSiteUrl('/stocks'), changeFrequency: 'weekly', priority: 0.9 },

--- a/src/app/stocks/_components/client/molecule-card.tsx
+++ b/src/app/stocks/_components/client/molecule-card.tsx
@@ -121,6 +121,16 @@ export function MoleculeCard({ molecule, index = 0 }: MoleculeCardProps) {
                                 <p className="text-foreground font-mono text-xs break-all">{molecule.inchikey}</p>
                             </div>
 
+                            <div className="space-y-1 border-t pt-3">
+                                <span className="text-muted-foreground text-xs font-semibold">Canonical Page</span>
+                                <Link
+                                    href={`/molecules/${molecule.inchikey}`}
+                                    className="text-primary block text-xs font-medium break-all underline-offset-2 hover:underline"
+                                >
+                                    {`/molecules/${molecule.inchikey}`}
+                                </Link>
+                            </div>
+
                             {hasBuyableData && molecule.stockItem && (
                                 <BuyableInfoSection
                                     source={molecule.stockItem.source!}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -2,6 +2,16 @@
  * Application constants and configuration.
  */
 
+export const SITE_URL = 'https://syntharena.ischemist.com'
+export const ISCHEMIST_URL = 'https://ischemist.com'
+export const NEWSLETTER_URL = `${ISCHEMIST_URL}/newsletter`
+export const STATUS_URL = 'https://status.ischemist.com'
+export const MOLECULE_SITEMAP_PAGE_SIZE = 50_000
+
+export function getSiteUrl(path: string = '/') {
+    return new URL(path, SITE_URL).toString()
+}
+
 /**
  * Benchmark IDs used for algorithm highlight metrics on detail pages.
  * These benchmarks are shown in the "Best Performance" section.

--- a/src/lib/domains/molecules/data/molecule.data.ts
+++ b/src/lib/domains/molecules/data/molecule.data.ts
@@ -1,0 +1,99 @@
+import { Prisma } from '@prisma/client'
+
+import prisma from '@/lib/db'
+
+const moleculeDetailSelect = {
+    id: true,
+    inchikey: true,
+    smiles: true,
+    _count: {
+        select: {
+            stockItems: true,
+            benchmarkTargets: true,
+            routeNodes: true,
+        },
+    },
+    stockItems: {
+        orderBy: {
+            stock: {
+                name: 'asc',
+            },
+        },
+        select: {
+            id: true,
+            ppg: true,
+            source: true,
+            leadTime: true,
+            link: true,
+            stock: {
+                select: {
+                    id: true,
+                    name: true,
+                    description: true,
+                },
+            },
+        },
+    },
+} satisfies Prisma.MoleculeSelect
+
+export type MoleculeDetailRow = Prisma.MoleculeGetPayload<{
+    select: typeof moleculeDetailSelect
+}>
+
+export async function findMoleculeByInchiKey(inchikey: string): Promise<MoleculeDetailRow | null> {
+    return prisma.molecule.findUnique({
+        where: { inchikey },
+        select: moleculeDetailSelect,
+    })
+}
+
+export async function findCanonicalInchiKeyByInchiKey(inchikey: string): Promise<string | null> {
+    const molecule = await prisma.molecule.findUnique({
+        where: { inchikey },
+        select: { inchikey: true },
+    })
+
+    return molecule?.inchikey ?? null
+}
+
+export async function findCanonicalInchiKeysBySmiles(smiles: string): Promise<string[]> {
+    const molecules = await prisma.molecule.findMany({
+        where: { smiles },
+        orderBy: { inchikey: 'asc' },
+        select: { inchikey: true },
+        take: 2,
+    })
+
+    return molecules.map((molecule) => molecule.inchikey)
+}
+
+export async function countIndexedMolecules(): Promise<number> {
+    return prisma.molecule.count({
+        where: {
+            stockItems: {
+                some: {},
+            },
+        },
+    })
+}
+
+export async function findIndexedMoleculesForSitemap(
+    limit: number,
+    offset: number
+): Promise<Array<{ inchikey: string }>> {
+    return prisma.molecule.findMany({
+        where: {
+            stockItems: {
+                some: {},
+            },
+        },
+        orderBy: {
+            inchikey: 'asc',
+        },
+        select: {
+            inchikey: true,
+        },
+        take: limit,
+        skip: offset,
+    })
+}

--- a/src/lib/domains/molecules/data/molecule.data.ts
+++ b/src/lib/domains/molecules/data/molecule.data.ts
@@ -1,3 +1,4 @@
+import { unstable_cache as cache } from 'next/cache'
 import { Prisma } from '@prisma/client'
 
 import prisma from '@/lib/db'
@@ -40,14 +41,17 @@ export type MoleculeDetailRow = Prisma.MoleculeGetPayload<{
     select: typeof moleculeDetailSelect
 }>
 
-export async function findMoleculeByInchiKey(inchikey: string): Promise<MoleculeDetailRow | null> {
+async function _findMoleculeByInchiKey(inchikey: string): Promise<MoleculeDetailRow | null> {
     return prisma.molecule.findUnique({
         where: { inchikey },
         select: moleculeDetailSelect,
     })
 }
+export const findMoleculeByInchiKey = cache(_findMoleculeByInchiKey, ['molecule-by-inchikey'], {
+    tags: ['molecules', 'stocks'],
+})
 
-export async function findCanonicalInchiKeyByInchiKey(inchikey: string): Promise<string | null> {
+async function _findCanonicalInchiKeyByInchiKey(inchikey: string): Promise<string | null> {
     const molecule = await prisma.molecule.findUnique({
         where: { inchikey },
         select: { inchikey: true },
@@ -55,19 +59,30 @@ export async function findCanonicalInchiKeyByInchiKey(inchikey: string): Promise
 
     return molecule?.inchikey ?? null
 }
+export const findCanonicalInchiKeyByInchiKey = cache(_findCanonicalInchiKeyByInchiKey, ['canonical-inchikey'], {
+    tags: ['molecules'],
+})
 
-export async function findCanonicalInchiKeysBySmiles(smiles: string): Promise<string[]> {
+async function _findCanonicalInchiKeysBySmiles(smiles: string): Promise<string[]> {
     const molecules = await prisma.molecule.findMany({
         where: { smiles },
         orderBy: { inchikey: 'asc' },
         select: { inchikey: true },
+        // Fetch at most two matches so the caller can distinguish unique from ambiguous SMILES lookups.
         take: 2,
     })
 
     return molecules.map((molecule) => molecule.inchikey)
 }
+export const findCanonicalInchiKeysBySmiles = cache(
+    _findCanonicalInchiKeysBySmiles,
+    ['canonical-inchikeys-by-smiles'],
+    {
+        tags: ['molecules'],
+    }
+)
 
-export async function countIndexedMolecules(): Promise<number> {
+async function _countIndexedMolecules(): Promise<number> {
     return prisma.molecule.count({
         where: {
             stockItems: {
@@ -76,11 +91,11 @@ export async function countIndexedMolecules(): Promise<number> {
         },
     })
 }
+export const countIndexedMolecules = cache(_countIndexedMolecules, ['indexed-molecule-count'], {
+    tags: ['molecules', 'stocks'],
+})
 
-export async function findIndexedMoleculesForSitemap(
-    limit: number,
-    offset: number
-): Promise<Array<{ inchikey: string }>> {
+async function _findIndexedMoleculesForSitemap(limit: number, offset: number): Promise<Array<{ inchikey: string }>> {
     return prisma.molecule.findMany({
         where: {
             stockItems: {
@@ -97,3 +112,10 @@ export async function findIndexedMoleculesForSitemap(
         skip: offset,
     })
 }
+export const findIndexedMoleculesForSitemap = cache(
+    _findIndexedMoleculesForSitemap,
+    ['indexed-molecules-for-sitemap'],
+    {
+        tags: ['molecules', 'stocks'],
+    }
+)

--- a/src/lib/domains/molecules/logic/molecule-query.logic.ts
+++ b/src/lib/domains/molecules/logic/molecule-query.logic.ts
@@ -1,0 +1,38 @@
+const HYPHENATED_INCHIKEY_PATTERN = /^[A-Z]{14}-[A-Z]{10}-[A-Z]$/
+const COMPACT_INCHIKEY_PATTERN = /^[A-Z]{25}$/
+
+export type MoleculeLookupQuery =
+    | { kind: 'empty' }
+    | { kind: 'inchikey'; inchikey: string }
+    | { kind: 'smiles'; smiles: string }
+
+export function normalizeInchiKeyCandidate(value: string): string | null {
+    const trimmedValue = value.trim()
+    if (!trimmedValue) return null
+
+    const uppercaseValue = trimmedValue.toUpperCase()
+    if (HYPHENATED_INCHIKEY_PATTERN.test(uppercaseValue)) {
+        return uppercaseValue
+    }
+
+    const compactValue = uppercaseValue.replaceAll('-', '')
+    if (!COMPACT_INCHIKEY_PATTERN.test(compactValue)) {
+        return null
+    }
+
+    return `${compactValue.slice(0, 14)}-${compactValue.slice(14, 24)}-${compactValue.slice(24)}`
+}
+
+export function parseMoleculeLookupQuery(rawQuery: string): MoleculeLookupQuery {
+    const trimmedQuery = rawQuery.trim()
+    if (!trimmedQuery) {
+        return { kind: 'empty' }
+    }
+
+    const normalizedInchikey = normalizeInchiKeyCandidate(trimmedQuery)
+    if (normalizedInchikey) {
+        return { kind: 'inchikey', inchikey: normalizedInchikey }
+    }
+
+    return { kind: 'smiles', smiles: trimmedQuery }
+}

--- a/src/lib/domains/molecules/view/molecule.view.ts
+++ b/src/lib/domains/molecules/view/molecule.view.ts
@@ -29,7 +29,7 @@ export interface MoleculeDetailPageData {
 export const getMoleculeDetailPageData = cache(async (inchikey: string): Promise<MoleculeDetailPageData> => {
     const molecule = await moleculeData.findMoleculeByInchiKey(inchikey)
     if (!molecule) {
-        throw new Error('molecule not found.')
+        throw new Error('Molecule not found')
     }
 
     const buyableStockCount = molecule.stockItems.filter(

--- a/src/lib/domains/molecules/view/molecule.view.ts
+++ b/src/lib/domains/molecules/view/molecule.view.ts
@@ -1,0 +1,74 @@
+import type { VendorSource } from '@/types'
+
+import * as moleculeData from '../data/molecule.data'
+import { parseMoleculeLookupQuery } from '../logic/molecule-query.logic'
+
+export interface MoleculeDetailPageData {
+    id: string
+    inchikey: string
+    smiles: string
+    stockCount: number
+    benchmarkTargetCount: number
+    routeNodeCount: number
+    buyableStockCount: number
+    stockEntries: Array<{
+        id: string
+        source?: VendorSource | null
+        ppg?: number | null
+        leadTime?: string | null
+        link?: string | null
+        stock: {
+            id: string
+            name: string
+            description?: string | null
+        }
+    }>
+}
+
+export async function getMoleculeDetailPageData(inchikey: string): Promise<MoleculeDetailPageData> {
+    const molecule = await moleculeData.findMoleculeByInchiKey(inchikey)
+    if (!molecule) {
+        throw new Error('molecule not found.')
+    }
+
+    const buyableStockCount = molecule.stockItems.filter(
+        (stockItem) => stockItem.source != null && stockItem.ppg != null
+    ).length
+
+    return {
+        id: molecule.id,
+        inchikey: molecule.inchikey,
+        smiles: molecule.smiles,
+        stockCount: molecule._count.stockItems,
+        benchmarkTargetCount: molecule._count.benchmarkTargets,
+        routeNodeCount: molecule._count.routeNodes,
+        buyableStockCount,
+        stockEntries: molecule.stockItems.map((stockItem) => ({
+            id: stockItem.id,
+            source: stockItem.source,
+            ppg: stockItem.ppg,
+            leadTime: stockItem.leadTime,
+            link: stockItem.link,
+            stock: {
+                id: stockItem.stock.id,
+                name: stockItem.stock.name,
+                description: stockItem.stock.description,
+            },
+        })),
+    }
+}
+
+export async function resolveMoleculeCanonicalInchiKey(rawQuery: string): Promise<string | null> {
+    const parsedQuery = parseMoleculeLookupQuery(rawQuery)
+
+    switch (parsedQuery.kind) {
+        case 'empty':
+            return null
+        case 'inchikey':
+            return moleculeData.findCanonicalInchiKeyByInchiKey(parsedQuery.inchikey)
+        case 'smiles': {
+            const matches = await moleculeData.findCanonicalInchiKeysBySmiles(parsedQuery.smiles)
+            return matches.length === 1 ? matches[0] : null
+        }
+    }
+}

--- a/src/lib/domains/molecules/view/molecule.view.ts
+++ b/src/lib/domains/molecules/view/molecule.view.ts
@@ -1,3 +1,4 @@
+import { cache } from 'react'
 import type { VendorSource } from '@/types'
 
 import * as moleculeData from '../data/molecule.data'
@@ -25,7 +26,7 @@ export interface MoleculeDetailPageData {
     }>
 }
 
-export async function getMoleculeDetailPageData(inchikey: string): Promise<MoleculeDetailPageData> {
+export const getMoleculeDetailPageData = cache(async (inchikey: string): Promise<MoleculeDetailPageData> => {
     const molecule = await moleculeData.findMoleculeByInchiKey(inchikey)
     if (!molecule) {
         throw new Error('molecule not found.')
@@ -56,8 +57,15 @@ export async function getMoleculeDetailPageData(inchikey: string): Promise<Molec
             },
         })),
     }
-}
+})
 
+/**
+ * Resolves a canonical molecule page from either:
+ * - an exact InChIKey, or
+ * - an exact canonical SMILES string already stored in the database.
+ *
+ * Non-canonical/equivalent SMILES representations are intentionally out of scope for now.
+ */
 export async function resolveMoleculeCanonicalInchiKey(rawQuery: string): Promise<string | null> {
     const parsedQuery = parseMoleculeLookupQuery(rawQuery)
 

--- a/src/lib/domains/molecules/view/molecule.view.ts
+++ b/src/lib/domains/molecules/view/molecule.view.ts
@@ -4,6 +4,19 @@ import type { VendorSource } from '@/types'
 import * as moleculeData from '../data/molecule.data'
 import { parseMoleculeLookupQuery } from '../logic/molecule-query.logic'
 
+export interface MoleculeStockEntry {
+    id: string
+    source?: VendorSource | null
+    ppg?: number | null
+    leadTime?: string | null
+    link?: string | null
+    stock: {
+        id: string
+        name: string
+        description?: string | null
+    }
+}
+
 export interface MoleculeDetailPageData {
     id: string
     inchikey: string
@@ -12,18 +25,7 @@ export interface MoleculeDetailPageData {
     benchmarkTargetCount: number
     routeNodeCount: number
     buyableStockCount: number
-    stockEntries: Array<{
-        id: string
-        source?: VendorSource | null
-        ppg?: number | null
-        leadTime?: string | null
-        link?: string | null
-        stock: {
-            id: string
-            name: string
-            description?: string | null
-        }
-    }>
+    stockEntries: MoleculeStockEntry[]
 }
 
 export const getMoleculeDetailPageData = cache(async (inchikey: string): Promise<MoleculeDetailPageData> => {

--- a/tests/lib/domains/molecules/logic/molecule-query.logic.test.ts
+++ b/tests/lib/domains/molecules/logic/molecule-query.logic.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+    normalizeInchiKeyCandidate,
+    parseMoleculeLookupQuery,
+} from '@/lib/domains/molecules/logic/molecule-query.logic'
+
+describe('normalizeInchiKeyCandidate', () => {
+    it('keeps a canonical hyphenated inchikey intact', () => {
+        expect(normalizeInchiKeyCandidate('BSYNRYMUTXBXSQ-UHFFFAOYSA-N')).toBe('BSYNRYMUTXBXSQ-UHFFFAOYSA-N')
+    })
+
+    it('normalizes lowercase inchikey input', () => {
+        expect(normalizeInchiKeyCandidate('bsynrymutxbxsq-uhfffaoysa-n')).toBe('BSYNRYMUTXBXSQ-UHFFFAOYSA-N')
+    })
+
+    it('restores missing hyphens for compact inchikey input', () => {
+        expect(normalizeInchiKeyCandidate('BSYNRYMUTXBXSQUHFFFAOYSAN')).toBe('BSYNRYMUTXBXSQ-UHFFFAOYSA-N')
+    })
+
+    it('rejects non-inchikey strings', () => {
+        expect(normalizeInchiKeyCandidate('CCO')).toBeNull()
+    })
+})
+
+describe('parseMoleculeLookupQuery', () => {
+    it('classifies empty input explicitly', () => {
+        expect(parseMoleculeLookupQuery('   ')).toEqual({ kind: 'empty' })
+    })
+
+    it('classifies inchikey input after normalization', () => {
+        expect(parseMoleculeLookupQuery('bsynrymutxbxsq-uhfffaoysa-n')).toEqual({
+            kind: 'inchikey',
+            inchikey: 'BSYNRYMUTXBXSQ-UHFFFAOYSA-N',
+        })
+    })
+
+    it('treats everything else as smiles input', () => {
+        expect(parseMoleculeLookupQuery('CC(=O)Oc1ccccc1C(=O)O')).toEqual({
+            kind: 'smiles',
+            smiles: 'CC(=O)Oc1ccccc1C(=O)O',
+        })
+    })
+})


### PR DESCRIPTION
## why
syntharena was seeing meaningful ai crawler traffic, but the app did not offer a stable molecule permalink, a clean resolver for inchikey/canonical smiles lookup, or crawler-facing metadata surfaces such as `robots.txt`, `sitemap.xml`, and `llms.txt`.

that made the site harder to cite, harder for agents to discover in a structured way, and awkward to use as a canonical source for molecule-level availability checks.

## what changed
- added a new `src/lib/domains/molecules` read slice with molecule lookup normalization, canonical inchikey resolution, and molecule detail dto composition
- added canonical molecule pages at `/molecules/[inchikey]` plus `/molecules/resolve?q=` for exact inchikey or canonical smiles resolution
- added molecule breadcrumbs, canonical-page links from stock cards, and a quieter provenance/citation note on the molecule page
- added `metadataBase`, `robots.ts`, root sitemap generation, sharded molecule sitemaps, and `llms.txt`
- added request-level dedup for molecule detail reads so the page metadata, page body, and breadcrumb path do not re-run the same molecule query during one render
- documented that non-canonical/equivalent smiles resolution is intentionally out of scope for now

## risk
low to medium.

this change is read-only, but it adds new public crawler-facing surfaces that may receive high request volume. there are no data writes or mutation invariants involved, but the new metadata routes and molecule pages do increase read traffic against sqlite-backed domain queries.

canonical smiles resolution is intentionally narrow: only exact canonical smiles strings already stored in the database resolve. ambiguous or non-canonical equivalents do not.

## verification
- `pnpm format`
- `pnpm check-types`
- `pnpm lint`
- direct db-backed smoke using `DATABASE_URL='file:./prisma/dev.db' pnpm exec tsx -e ...` to confirm molecule detail lookup plus lowercase-inchikey and canonical-smiles resolution on a real molecule

## follow-ups
- broader cross-request caching for crawler-heavy metadata routes is still a repo-level operational question rather than something this branch fully solves
- `vitest` is currently blocked by the repo's prisma test-db setup: `pnpm exec prisma db push` fails in global test setup with a schema engine error

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ischemist/codesmith/syntharena/pr/81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rich molecule detail pages with identifiers, SMILES, copyable canonical URL, stock availability table, and breadcrumbs; hovercards link to canonical molecule pages
  * Query resolver that redirects searches to canonical molecule pages
  * Plain-text llms.txt endpoint

* **SEO Enhancements**
  * Per-molecule and site sitemaps, robots rules, and metadata base URL improvements

* **Tests**
  * Added tests for InChIKey normalization and lookup parsing

* **Chores**
  * Updated .gitignore

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ischemist/syntharena/pull/81)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds canonical molecule detail pages at `/molecules/[inchikey]`, a query resolver at `/molecules/resolve`, and crawler-facing metadata surfaces (`robots.txt`, sharded molecule sitemaps, `llms.txt`). It also introduces a new `src/lib/domains/molecules` read slice with `react.cache`-based request dedup layered on top of `unstable_cache` cross-request caching, and adds canonical page links to existing molecule hover cards.

- **New public surfaces**: canonical molecule pages, resolve redirect, robots/sitemap/llms.txt — all read-only with correct try/catch fallbacks so crawlers receive valid responses even under transient DB unavailability.
- **Caching strategy**: `getMoleculeDetailPageData` uses `react.cache` (request-level dedup) over `unstable_cache` (cross-request); the layering is sound but the function throws on not-found, causing `generateMetadata` and the page body to each independently catch and log that same memoized rejection — two `console.error` entries per 404.
- **Data layer**: all five Prisma queries in `molecule.data.ts` use parameterized lookups via Prisma, external vendor URLs are sanitized to `http`/`https` only, and sitemap pagination is offset-based with consistent ordering by `inchikey`.

<h3>Confidence Score: 5/5</h3>

Read-only change with no schema mutations; all new public routes fall back gracefully on DB errors

All changes are reads against existing tables. Error handling across sitemaps, robots, and the resolver is consistent and defensive. The only issue found is log noise from react.cache replaying a memoized rejection at two call sites on 404 requests, which does not affect correctness or data integrity.

src/app/molecules/[inchikey]/page.tsx and src/lib/domains/molecules/view/molecule.view.ts — the double-logging interaction between generateMetadata and the page body for not-found molecules

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/app/molecules/[inchikey]/page.tsx | Canonical molecule detail page with generateMetadata + page body both catching the same react.cache-memoized rejection, producing two console.error entries per 404 request |
| src/lib/domains/molecules/view/molecule.view.ts | New view layer with getMoleculeDetailPageData (react.cache) and resolveMoleculeCanonicalInchiKey; throws on not-found which causes double-logging at its two call sites |
| src/lib/domains/molecules/data/molecule.data.ts | New data access layer using unstable_cache for all molecule queries; pagination, tag invalidation, and Prisma selects look correct |
| src/lib/domains/molecules/logic/molecule-query.logic.ts | InChIKey normalization logic; compact-form detection strips hyphens before pattern match (previously flagged stray-hyphen edge case) but blast radius is limited to 404s |
| src/app/sitemap.ts | Root sitemap now wraps getStocks() in try/catch and falls back to STATIC_ROUTES; error handling matches the pattern in sibling sitemap files |
| src/app/molecules/sitemap.ts | Sharded molecule sitemaps with try/catch in both generateSitemaps and sitemap(); DB errors degrade gracefully to empty/partial sitemaps |
| src/app/robots.ts | robots.txt generation with try/catch around countIndexedMolecules(); correctly disallows /molecules/resolve and lists sharded sitemap URLs |
| src/app/molecules/resolve/page.tsx | Resolver that redirects to canonical molecule page; previously flagged console.error on expected 404s is a known open item |
| src/app/llms.txt/route.ts | Static llms.txt with 1-hour cache; URL constants referenced are all statically composed from SITE_URL |
| src/app/molecules/[inchikey]/_components/server/molecule-detail-content.tsx | Molecule detail UI; getSafeExternalHref correctly restricts external vendor links to http/https only |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Crawler
    participant NextJS as Next.js App Router
    participant ViewLayer as molecule.view.ts (react.cache)
    participant DataLayer as molecule.data.ts (unstable_cache)
    participant DB as SQLite (Prisma)

    Crawler->>NextJS: GET /molecules/[inchikey]
    NextJS->>ViewLayer: generateMetadata → getMoleculeDetailPageData(inchikey)
    ViewLayer->>DataLayer: findMoleculeByInchiKey(inchikey)
    DataLayer->>DB: "SELECT WHERE inchikey = ?"
    DB-->>DataLayer: "row | null"
    DataLayer-->>ViewLayer: "MoleculeDetailRow | null"
    ViewLayer-->>NextJS: MoleculeDetailPageData (cached in react.cache)
    NextJS->>ViewLayer: page body → getMoleculeDetailPageData(inchikey)
    Note over ViewLayer: react.cache hit — no DB round-trip
    ViewLayer-->>NextJS: MoleculeDetailPageData (from cache)

    Crawler->>NextJS: "GET /molecules/resolve?q=query"
    NextJS->>ViewLayer: resolveMoleculeCanonicalInchiKey(q)
    ViewLayer->>DataLayer: findCanonicalInchiKeyByInchiKey / findCanonicalInchiKeysBySmiles
    DataLayer->>DB: SELECT inchikey
    DB-->>DataLayer: result
    DataLayer-->>ViewLayer: "inchikey | null"
    ViewLayer-->>NextJS: "inchikey | null"
    NextJS-->>Crawler: "302 /molecules/[inchikey] | 404"

    Crawler->>NextJS: GET /molecules/sitemap/0.xml
    NextJS->>DataLayer: findIndexedMoleculesForSitemap(50000, 0)
    DataLayer->>DB: SELECT inchikey WHERE stockItems.some LIMIT 50000
    DB-->>DataLayer: "[{inchikey}]"
    DataLayer-->>NextJS: MetadataRoute.Sitemap
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/app/molecules/[inchikey]/page.tsx:48-84
**Double console.error per 404 due to `react.cache` error memoization**

`getMoleculeDetailPageData` is wrapped with `react.cache`, which memoizes rejected promises within a request. When a molecule doesn't exist, `generateMetadata` (lines 48–64) triggers the lookup, `getMoleculeDetailPageData` throws `"Molecule not found"`, and `react.cache` stores that rejection. `generateMetadata` catches it and logs `console.error`. When `MoleculeDetailPage` (lines 76–84) subsequently calls the same cached function, React replays the stored rejection and the page body's catch block fires a second `console.error` — two log entries per 404 request on a crawler-heavy surface with no real DB work on the second call.

The root cause is that `getMoleculeDetailPageData` uses exceptions for expected control flow (not found vs. DB error). Returning `null` for the not-found case and throwing only for actual DB errors would let callers distinguish the two paths without any logging for expected 404s.

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix: harden molecule sitemap generation"](https://github.com/ischemist/syntharena/commit/0e499cd3b308d41dbe5e2cfb6547839f210b36bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31456034)</sub>

<!-- /greptile_comment -->