### PR TITLE
feat: upgrade retrocast v0.7 schema loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,9 @@ If you want to evaluate your own models or create a custom benchmark, you can ge
 3. Ensure you have the following outputs:
     - Benchmark definitions: `data/1-benchmarks/definitions/*.json.gz`
     - Stock definitions: `data/1-benchmarks/stocks/*.txt`
-    - Processed routes: `data/3-processed/<benchmark>/<model>/routes.json.gz`
+    - Processed candidates: `data/3-processed/<benchmark>/<model>/candidates.json.gz`
     - Evaluations: `data/4-scored/<benchmark>/<model>/<stock>/evaluation.json.gz`
-    - Statistics: `data/5-results/<benchmark>/<model>/<stock>/statistics.json.gz`
+    - Analysis: `data/5-results/<benchmark>/<model>/<stock>/analysis.json.gz`
 
 ### Loading Data
 

--- a/ischemist.toml
+++ b/ischemist.toml
@@ -1,4 +1,3 @@
 [practices]
-source = "/Users/morgunov/Developer/engineering-practices"
 profile = "next-prisma-app"
 output = ".practices/docs"

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
         "format:check": "oxfmt --check"
     },
     "dependencies": {
-        "@ischemist/route-viewer": "0.0.7",
-        "@ischemist/routes": "0.0.4",
+        "@ischemist/route-viewer": "0.1.0",
+        "@ischemist/routes": "0.1.0",
         "@prisma/adapter-better-sqlite3": "^7.0.0",
         "@prisma/client": "^7.8.0",
         "@radix-ui/react-avatar": "^1.1.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@ischemist/route-viewer':
-        specifier: 0.0.7
-        version: 0.0.7(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: 0.1.0
+        version: 0.1.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@ischemist/routes':
-        specifier: 0.0.4
-        version: 0.0.4
+        specifier: 0.1.0
+        version: 0.1.0
       '@prisma/adapter-better-sqlite3':
         specifier: ^7.0.0
         version: 7.0.0
@@ -782,14 +782,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@ischemist/route-viewer@0.0.7':
-    resolution: {integrity: sha512-hUGiJMTEeA79WV3svi7c6M3gHyRBck6jH/GLVYTUysG0LWyvZjfaP04rv2phQMvQPqK4ATaAqUYLJPuE2eWh8w==}
+  '@ischemist/route-viewer@0.1.0':
+    resolution: {integrity: sha512-qvBZSl70/INZFvqLPFFocXuTa/mckVs/qa0NZaefcvdnSub9mHV+IiiKLxmyhuLtSKar8/BJVWWKS8hUzn/idg==}
     peerDependencies:
       react: '>=19'
       react-dom: '>=19'
 
-  '@ischemist/routes@0.0.4':
-    resolution: {integrity: sha512-TNiBaDxbTtegRPIqJMj1Vc+viZIED1VM3oRrGeltpGUZS1EEz7aC9FFxd8/AnjfVf4M6ob+OCqkhUSkfJDGorg==}
+  '@ischemist/routes@0.1.0':
+    resolution: {integrity: sha512-1KuNTjeyL1SUlNOLnSIlpVMCYvmdzaXIJeRqti7C6nR6EWOTEjEe38vfgeOOtH0VFjNrILtC5AdUdxSqKlG6rw==}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -1980,6 +1980,19 @@ packages:
   '@vitest/utils@4.0.14':
     resolution: {integrity: sha512-hLqXZKAWNg8pI+SQXyXxWCTOpA3MvsqcbVeNgSi8x/CSN2wi26dSzn1wrOhmCmFjEvN9p8/kLFRHa6PI8jHazw==}
 
+  '@xyflow/react@12.11.0':
+    resolution: {integrity: sha512-na4IO33FSs2OS72hASgZDmTYwFAkef7Z74uBUVrong3ARmQQHfnRUVaCFn1kTt5LbS6pK03TbYjCPGLjLFfziA==}
+    peerDependencies:
+      '@types/react': '>=17'
+      '@types/react-dom': '>=17'
+      react: '>=17'
+      react-dom: '>=17'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@xyflow/react@12.9.3':
     resolution: {integrity: sha512-PSWoJ8vHiEqSIkLIkge+0eiHWiw4C6dyFDA03VKWJkqbU4A13VlDIVwKqf/Znuysn2GQw/zA61zpHE4rGgax7Q==}
     peerDependencies:
@@ -1988,6 +2001,9 @@ packages:
 
   '@xyflow/system@0.0.73':
     resolution: {integrity: sha512-C2ymH2V4mYDkdVSiRx0D7R0s3dvfXiupVBcko6tXP5K4tVdSBMo22/e3V9yRNdn+2HQFv44RFKzwOyCcUUDAVQ==}
+
+  '@xyflow/system@0.0.77':
+    resolution: {integrity: sha512-qCDCMCQAAgUu8yHnhloHG9F5mwPX5E+Wl8McpYIOPSSXfzFJJoZcwOcsDiAjitVKIg2de1WmJbCHfpcvxprsgg==}
 
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
@@ -2590,8 +2606,8 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  lucide-react@1.9.0:
-    resolution: {integrity: sha512-6qVAmbgCjcJz7sAGSPSSJ++RAwjlK2XCbRrZKv63Ciko1KT8jX0//CXxgI3jg2HlJu8tADqdYlNDebmYjeoruA==}
+  lucide-react@1.17.0:
+    resolution: {integrity: sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -3024,6 +3040,9 @@ packages:
 
   smiles-drawer@2.1.7:
     resolution: {integrity: sha512-gApm5tsWrAYDkjbGYQb5OhwIyHvtM2kIO40DfATaOV0DPm0wA63yn4Ow7us27BT49lDdU9busCOPN9fpyonzaA==}
+
+  smiles-drawer@2.2.1:
+    resolution: {integrity: sha512-PM49IH6DbkURkxivNPU9k6TpTlSPdyNpPmPDx/C7sbMqxvlPs3plaMVcDOH0GHnjHYdorQuYL/CJ5vkZkYKqUQ==}
 
   sonner@2.0.7:
     resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
@@ -3669,19 +3688,20 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@ischemist/route-viewer@0.0.7(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@ischemist/route-viewer@0.1.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@ischemist/routes': 0.0.4
-      '@xyflow/react': 12.9.3(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      lucide-react: 1.9.0(react@19.2.0)
+      '@ischemist/routes': 0.1.0
+      '@xyflow/react': 12.11.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      lucide-react: 1.17.0(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      smiles-drawer: 2.1.7
+      smiles-drawer: 2.2.1
     transitivePeerDependencies:
       - '@types/react'
+      - '@types/react-dom'
       - immer
 
-  '@ischemist/routes@0.0.4': {}
+  '@ischemist/routes@0.1.0': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -4760,6 +4780,19 @@ snapshots:
       '@vitest/pretty-format': 4.0.14
       tinyrainbow: 3.0.3
 
+  '@xyflow/react@12.11.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@xyflow/system': 0.0.77
+      classcat: 5.0.5
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+      zustand: 4.5.7(@types/react@19.2.7)(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+    transitivePeerDependencies:
+      - immer
+
   '@xyflow/react@12.9.3(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@xyflow/system': 0.0.73
@@ -4772,6 +4805,18 @@ snapshots:
       - immer
 
   '@xyflow/system@0.0.73':
+    dependencies:
+      '@types/d3-drag': 3.0.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+
+  '@xyflow/system@0.0.77':
     dependencies:
       '@types/d3-drag': 3.0.7
       '@types/d3-interpolate': 3.0.4
@@ -5342,7 +5387,7 @@ snapshots:
     dependencies:
       react: 19.2.0
 
-  lucide-react@1.9.0(react@19.2.0):
+  lucide-react@1.17.0(react@19.2.0):
     dependencies:
       react: 19.2.0
 
@@ -5797,6 +5842,10 @@ snapshots:
       is-fullwidth-code-point: 5.1.0
 
   smiles-drawer@2.1.7:
+    dependencies:
+      chroma-js: 2.6.0
+
+  smiles-drawer@2.2.1:
     dependencies:
       chroma-js: 2.6.0
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -243,7 +243,7 @@ model ReactionStep {
   id           String  @id @default(cuid())
   reactionHash String  @unique // SHA256 of "productInchikey>>reactant1Inchikey.reactant2Inchikey" (sorted)
   template     String? // Reaction template (e.g., SMARTS pattern)
-  metadata     String? // JSON: reagents, solvents, mapped_smiles
+  metadata     String? // JSON: reagents, solvents, mapped_reaction_smiles
 
   nodes RouteNode[]
 }

--- a/scripts/load-benchmark.ts
+++ b/scripts/load-benchmark.ts
@@ -29,9 +29,9 @@
  *         "target-id": {
  *           "id": "target-id",
  *           "smiles": "target-smiles",
- *           "inchi_key": "...",
+ *           "inchikey": "...",
  *           "acceptable_routes": [...],
- *           "metadata": {...}
+ *           "annotations": {...}
  *         }
  *       }
  *     }

--- a/scripts/load-predictions.ts
+++ b/scripts/load-predictions.ts
@@ -51,8 +51,8 @@
  * The script will:
  *   1. Resolve or create Algorithm, ModelFamily, and ModelInstance.
  *   2. Create or update PredictionRun for benchmark+instance combination.
- *   3. Load routes from 3-processed.
- *   4. If --stock specified, load evaluations from 4-scored and statistics from 5-results.
+ *   3. Load candidates from 3-processed.
+ *   4. If --stock specified, load evaluations from 4-scored and analysis from 5-results.
  *   5. Update aggregate statistics on PredictionRun and report summary.
  */
 import * as fs from 'fs'
@@ -67,10 +67,10 @@ import {
     createOrUpdatePredictionRun,
     createRouteFromPython,
     createRouteSolvability,
-    transformPythonStatistics,
+    transformRetrocastAnalysis,
     updatePredictionRunCost,
     updatePredictionRunStats,
-    type PythonModelStatistics,
+    type RetrocastAnalysis,
     type PythonRoute,
 } from '../src/lib/services/loaders/prediction-loader.service'
 
@@ -78,30 +78,32 @@ import {
 // Types for File Formats
 // ============================================================================
 
-interface RoutesFile {
-    [targetId: string]: PythonRoute[]
+interface CandidatesFile {
+    [targetId: string]: Array<{
+        rank: number
+        route?: (Omit<PythonRoute, 'rank'> & { rank?: number }) | null
+        failure?: unknown
+    }>
 }
 
-interface EvaluationFile {
-    model_name: string
-    benchmark_name: string
-    stock_name: string
-    has_acceptable_routes: boolean
-    results: {
+interface RetrocastEvaluationArtifact {
+    targets: {
         [targetId: string]: {
-            target_id: string
-            routes: Array<{
+            target: {
+                acceptable_routes?: Array<Omit<PythonRoute, 'rank'> & { rank?: number }>
+            }
+            candidates: Array<{
                 rank: number
-                is_solved: boolean
-                matches_acceptable: boolean
-                matched_acceptable_index: number | null
+                route?: (Omit<PythonRoute, 'rank'> & { rank?: number }) | null
+                validity?: {
+                    tiers?: Record<string, { status?: string }>
+                }
+                constraints?: {
+                    status?: string
+                }
+                matches_acceptable?: boolean
+                matched_acceptable_index?: number | null
             }>
-            is_solvable: boolean
-            acceptable_rank: number | null
-            // Stratification fields (renamed in Python TargetEvaluation)
-            stratification_length: number | null
-            stratification_is_convergent: boolean | null
-            // Runtime metrics (in seconds)
             wall_time: number | null
             cpu_time: number | null
         }
@@ -248,6 +250,20 @@ function fileExists(filePath: string): boolean {
     }
 }
 
+function routeFromCandidate(candidate: CandidatesFile[string][number]): PythonRoute | null {
+    if (!candidate.route) return null
+    return {
+        ...candidate.route,
+        rank: candidate.rank,
+    }
+}
+
+function candidateIsSolved(candidate: RetrocastEvaluationArtifact['targets'][string]['candidates'][number]): boolean {
+    const constraintsPass = candidate.constraints?.status === 'pass'
+    const tierZeroStatus = candidate.validity?.tiers?.['0']?.status
+    return constraintsPass && (tierZeroStatus === undefined || tierZeroStatus === 'pass')
+}
+
 // ============================================================================
 // Main Loading Logic
 // ============================================================================
@@ -380,8 +396,8 @@ async function main() {
         console.log('')
 
         // --- Step 2: File Paths & Run Creation ---
-        const routesFile = path.join(dataDir, '3-processed', benchmark.name, modelPathName, 'routes.json.gz')
-        if (!fileExists(routesFile)) throw new Error(`routes file not found: ${routesFile}`)
+        const candidatesFile = path.join(dataDir, '3-processed', benchmark.name, modelPathName, 'candidates.json.gz')
+        if (!fileExists(candidatesFile)) throw new Error(`candidates file not found: ${candidatesFile}`)
 
         const manifestFile = path.join(dataDir, '3-processed', benchmark.name, modelPathName, 'manifest.json')
         const manifest = fileExists(manifestFile)
@@ -396,11 +412,11 @@ async function main() {
         console.log(`prediction run upserted: ${predictionRun.id}`)
         console.log('')
 
-        // --- Step 3: Load Routes ---
-        console.log(`loading routes from ${routesFile}...`)
-        const routesData = await readGzipJson<RoutesFile>(routesFile)
+        // --- Step 3: Load Candidates ---
+        console.log(`loading candidates from ${candidatesFile}...`)
+        const candidatesData = await readGzipJson<CandidatesFile>(candidatesFile)
         let routesCreated = 0
-        const targetIdsInFile = Object.keys(routesData)
+        const targetIdsInFile = Object.keys(candidatesData)
 
         for (const [i, externalTargetId] of targetIdsInFile.entries()) {
             if (i % 20 === 0) console.log(`  target ${i + 1}/${targetIdsInFile.length}...`)
@@ -412,7 +428,10 @@ async function main() {
                 console.warn(`  skipping: target '${externalTargetId}' not found in benchmark '${benchmark.name}'`)
                 continue
             }
-            for (const pythonRoute of routesData[externalTargetId]) {
+            const routes = candidatesData[externalTargetId]
+                .map(routeFromCandidate)
+                .filter((route): route is PythonRoute => route !== null)
+            for (const pythonRoute of routes) {
                 await createRouteFromPython(pythonRoute, predictionRun.id, target.id)
                 routesCreated++
             }
@@ -434,27 +453,29 @@ async function main() {
                 stockPathName,
                 'evaluation.json.gz'
             )
-            const statisticsFile = path.join(
+            const analysisFile = path.join(
                 dataDir,
                 '5-results',
                 benchmark.name,
                 modelPathName,
                 stockPathName,
-                'statistics.json.gz'
+                'analysis.json.gz'
             )
 
             if (!fileExists(evaluationFile)) throw new Error(`evaluation file not found: ${evaluationFile}`)
-            if (!fileExists(statisticsFile)) throw new Error(`statistics file not found: ${statisticsFile}`)
+            if (!fileExists(analysisFile)) throw new Error(`analysis file not found: ${analysisFile}`)
 
             // Load Evaluations
             console.log(`loading evaluations for stock '${stock.name}'...`)
-            const evaluationData = await readGzipJson<EvaluationFile>(evaluationFile)
+            const evaluationData = await readGzipJson<RetrocastEvaluationArtifact>(evaluationFile)
             let solvabilityRecordsCreated = 0
-            for (const externalTargetId in evaluationData.results) {
-                const targetEval = evaluationData.results[externalTargetId]
+            for (const externalTargetId in evaluationData.targets) {
+                const targetEval = evaluationData.targets[externalTargetId]
                 const target = await prisma.benchmarkTarget.findUnique({
-                    where: { benchmarkSetId_targetId: { benchmarkSetId: benchmark.id, targetId: externalTargetId } },
-                    select: { id: true },
+                    where: {
+                        benchmarkSetId_targetId: { benchmarkSetId: benchmark.id, targetId: externalTargetId },
+                    },
+                    select: { id: true, routeLength: true, isConvergent: true },
                 })
                 if (!target) continue
 
@@ -464,17 +485,17 @@ async function main() {
                 })
                 const rankToIdMap = new Map(predictionRoutes.map((pr) => [pr.rank, pr.id]))
 
-                for (const routeEval of targetEval.routes) {
-                    const predictionRouteId = rankToIdMap.get(routeEval.rank)
+                for (const candidate of targetEval.candidates) {
+                    const predictionRouteId = rankToIdMap.get(candidate.rank)
                     if (!predictionRouteId) continue
                     await createRouteSolvability(
                         predictionRouteId,
                         stock.id,
-                        routeEval.is_solved,
-                        routeEval.matches_acceptable,
-                        routeEval.matched_acceptable_index,
-                        targetEval.stratification_length,
-                        targetEval.stratification_is_convergent,
+                        candidateIsSolved(candidate),
+                        candidate.matches_acceptable ?? false,
+                        candidate.matched_acceptable_index ?? null,
+                        target.routeLength,
+                        target.isConvergent,
                         targetEval.wall_time,
                         targetEval.cpu_time
                     )
@@ -484,12 +505,11 @@ async function main() {
             console.log(`  solvability records created: ${solvabilityRecordsCreated}`)
             console.log('')
 
-            // Load Statistics
-            console.log('loading statistics...')
-            const rawStats = await readGzipJson<PythonModelStatistics>(statisticsFile)
-            const transformedStats = transformPythonStatistics(rawStats)
+            // Load Analysis
+            console.log('loading analysis...')
+            const transformedStats = transformRetrocastAnalysis(await readGzipJson<RetrocastAnalysis>(analysisFile))
             await createModelStatistics(predictionRun.id, benchmark.id, stock.id, transformedStats)
-            console.log(`  statistics loaded.`)
+            console.log(`  analysis loaded.`)
             console.log('')
         }
 

--- a/scripts/load-predictions.ts
+++ b/scripts/load-predictions.ts
@@ -259,7 +259,7 @@ function routeFromCandidate(candidate: CandidatesFile[string][number]): PythonRo
 }
 
 function candidateIsSolved(candidate: RetrocastEvaluationArtifact['targets'][string]['candidates'][number]): boolean {
-    const constraintsPass = candidate.constraints?.status === 'pass'
+    const constraintsPass = !candidate.constraints || candidate.constraints.status === 'pass'
     const tierZeroStatus = candidate.validity?.tiers?.['0']?.status
     return constraintsPass && (tierZeroStatus === undefined || tierZeroStatus === 'pass')
 }

--- a/src/app/(info)/docs/how-it-works/_components/pipeline-stages-section.tsx
+++ b/src/app/(info)/docs/how-it-works/_components/pipeline-stages-section.tsx
@@ -75,7 +75,7 @@ export function PipelineStagesSection() {
                             <div className="font-mono text-xs">
                                 data/3-processed/<span className="text-blue-600 dark:text-blue-400">&lt;model&gt;</span>
                                 /<span className="text-green-600 dark:text-green-400">&lt;benchmark&gt;</span>
-                                /routes.json.gz
+                                /candidates.json.gz
                             </div>
                         </div>
                         <div className="space-y-2">

--- a/src/lib/services/loaders/benchmark-loader.service.ts
+++ b/src/lib/services/loaders/benchmark-loader.service.ts
@@ -104,7 +104,7 @@ function computeReactionHash(step: PythonReactionStep, productInchikey: string):
     return crypto.createHash('sha256').update(content).digest('hex')
 }
 
-function getSynthesisStep(molecule: PythonMolecule): PythonReactionStep | null {
+function getProductOf(molecule: PythonMolecule): PythonReactionStep | null {
     return molecule.product_of ?? null
 }
 
@@ -113,7 +113,7 @@ function getAnnotations(value: { annotations?: Record<string, unknown> }): Recor
 }
 
 function normalizeMoleculeForRetrocast(molecule: PythonMolecule): RetrocastMolecule {
-    const step = getSynthesisStep(molecule)
+    const step = getProductOf(molecule)
     return {
         smiles: molecule.smiles,
         inchikey: molecule.inchikey,
@@ -192,7 +192,7 @@ function collectRouteTreeData(
     const tempId = `temp-${tempIdCounter.value++}`
 
     // Create node data
-    const step = getSynthesisStep(molecule)
+    const step = getProductOf(molecule)
     const isLeaf = !step || molecule.is_leaf === true
     const reactionHash = step ? computeReactionHash(step, molecule.inchikey) : null
 

--- a/src/lib/services/loaders/benchmark-loader.service.ts
+++ b/src/lib/services/loaders/benchmark-loader.service.ts
@@ -1,6 +1,8 @@
 import crypto from 'crypto'
 import * as fs from 'fs'
 import * as zlib from 'zlib'
+import { projectRetrocastRoute } from '@ischemist/routes'
+import type { RetrocastMolecule, RetrocastReaction, RetrocastRoute } from '@ischemist/routes'
 import { Prisma } from '@prisma/client'
 
 import type { LoadBenchmarkResult } from '@/types'
@@ -14,36 +16,36 @@ import { upsertReactionSteps } from '@/lib/services/loaders/reaction-step.helper
 interface PythonMolecule {
     smiles: string
     inchikey: string
-    synthesis_step: PythonReactionStep | null
-    metadata?: Record<string, unknown>
+    product_of?: PythonReactionStep | null
+    annotations?: Record<string, unknown>
     is_leaf?: boolean
 }
 
 interface PythonReactionStep {
     reactants: PythonMolecule[]
-    mapped_smiles?: string | null
+    mapped_reaction_smiles?: string | null
     template?: string | null
     reagents?: string[] | null
     solvents?: string[] | null
-    metadata?: Record<string, unknown>
+    annotations?: Record<string, unknown>
     is_convergent?: boolean
 }
 
 interface PythonRoute {
     target: PythonMolecule
-    rank: number
-    signature?: string
+    rank?: number
     length?: number
     has_convergent_reaction?: boolean
     solvability?: Record<string, boolean>
-    metadata?: Record<string, unknown>
+    annotations?: Record<string, unknown>
+    schema_version?: string
 }
 
 interface PythonBenchmarkTarget {
     id: string
     smiles: string
-    inchi_key: string // NOW REQUIRED: included directly in target (from Python model update)
-    metadata?: Record<string, unknown>
+    inchikey: string
+    annotations?: Record<string, unknown>
     acceptable_routes: PythonRoute[] // Array of acceptable routes (empty = pure prediction task)
 }
 
@@ -102,6 +104,47 @@ function computeReactionHash(step: PythonReactionStep, productInchikey: string):
     return crypto.createHash('sha256').update(content).digest('hex')
 }
 
+function getSynthesisStep(molecule: PythonMolecule): PythonReactionStep | null {
+    return molecule.product_of ?? null
+}
+
+function getAnnotations(value: { annotations?: Record<string, unknown> }): Record<string, unknown> {
+    return value.annotations ?? {}
+}
+
+function normalizeMoleculeForRetrocast(molecule: PythonMolecule): RetrocastMolecule {
+    const step = getSynthesisStep(molecule)
+    return {
+        smiles: molecule.smiles,
+        inchikey: molecule.inchikey,
+        ...(step ? { product_of: normalizeReactionForRetrocast(step) } : {}),
+        annotations: getAnnotations(molecule),
+    }
+}
+
+function normalizeReactionForRetrocast(step: PythonReactionStep): RetrocastReaction {
+    return {
+        reactants: step.reactants.map(normalizeMoleculeForRetrocast),
+        mapped_reaction_smiles: step.mapped_reaction_smiles ?? null,
+        template: step.template ?? null,
+        reagents: step.reagents ?? null,
+        solvents: step.solvents ?? null,
+        annotations: getAnnotations(step),
+    }
+}
+
+function normalizeRouteForRetrocast(route: PythonRoute): RetrocastRoute {
+    return {
+        target: normalizeMoleculeForRetrocast(route.target),
+        annotations: getAnnotations(route),
+        schema_version: '2',
+    }
+}
+
+function routeProjection(route: PythonRoute) {
+    return projectRetrocastRoute(normalizeRouteForRetrocast(route))
+}
+
 /**
  * Internal structure for building route nodes in memory before bulk insert.
  * Reaction data (reactionHash, template, metadata) is stored temporarily here
@@ -149,20 +192,20 @@ function collectRouteTreeData(
     const tempId = `temp-${tempIdCounter.value++}`
 
     // Create node data
-    const isLeaf = !molecule.synthesis_step
-    const reactionHash = molecule.synthesis_step
-        ? computeReactionHash(molecule.synthesis_step, molecule.inchikey)
-        : null
+    const step = getSynthesisStep(molecule)
+    const isLeaf = !step || molecule.is_leaf === true
+    const reactionHash = step ? computeReactionHash(step, molecule.inchikey) : null
 
-    // Prepare node metadata (reagents, solvents, mapped_smiles)
+    // Prepare node metadata (reagents, solvents, mapped_reaction_smiles)
     // Aligned with prediction-loader to ensure consistent ReactionStep.metadata format
     let metadata: string | null = null
-    if (molecule.synthesis_step) {
+    if (step) {
         const metadataObj: Record<string, unknown> = {}
-        if (molecule.synthesis_step.reagents) metadataObj.reagents = molecule.synthesis_step.reagents
-        if (molecule.synthesis_step.solvents) metadataObj.solvents = molecule.synthesis_step.solvents
-        if (molecule.synthesis_step.mapped_smiles) metadataObj.mapped_smiles = molecule.synthesis_step.mapped_smiles
-        if (molecule.synthesis_step.metadata) metadataObj.python_metadata = molecule.synthesis_step.metadata
+        if (step.reagents) metadataObj.reagents = step.reagents
+        if (step.solvents) metadataObj.solvents = step.solvents
+        if (step.mapped_reaction_smiles) metadataObj.mapped_reaction_smiles = step.mapped_reaction_smiles
+        const stepAnnotations = getAnnotations(step)
+        if (Object.keys(stepAnnotations).length > 0) metadataObj.annotations = stepAnnotations
         if (Object.keys(metadataObj).length > 0) {
             metadata = JSON.stringify(metadataObj)
         }
@@ -175,15 +218,15 @@ function collectRouteTreeData(
         parentTempId,
         isLeaf,
         reactionHash,
-        template: molecule.synthesis_step?.template || null,
+        template: step?.template || null,
         metadata,
         smiles: molecule.smiles,
     }
     nodes.push(node)
 
     // Recursively process reactants
-    if (molecule.synthesis_step?.reactants) {
-        for (const reactant of molecule.synthesis_step.reactants) {
+    if (step?.reactants) {
+        for (const reactant of step.reactants) {
             collectRouteTreeData(reactant, routeId, tempId, molecules, nodes, tempIdCounter)
         }
     }
@@ -300,102 +343,6 @@ async function storeRouteTree(
 }
 
 /**
- * Internal structure for in-memory route node representation.
- */
-interface InMemoryRouteNode {
-    id: string
-    isLeaf: boolean
-    childIds: string[]
-}
-
-/**
- * Computes route length and convergence in-memory using a single database query.
- * Fetches all nodes at once and performs graph traversal in memory.
- *
- * @param routeId - The route ID
- * @param tx - Transaction client
- * @returns Object with length and isConvergent properties
- */
-async function computeRouteProperties(
-    routeId: string,
-    tx: Prisma.TransactionClient
-): Promise<{ length: number; isConvergent: boolean }> {
-    // Fetch all nodes for this route in a single query
-    const nodes = await tx.routeNode.findMany({
-        where: { routeId },
-        select: {
-            id: true,
-            parentId: true,
-            isLeaf: true,
-        },
-    })
-
-    if (nodes.length === 0) {
-        return { length: 0, isConvergent: false }
-    }
-
-    // Build in-memory graph structure
-    const nodeMap = new Map<string, InMemoryRouteNode>()
-    let rootId: string | null = null
-
-    for (const node of nodes) {
-        nodeMap.set(node.id, {
-            id: node.id,
-            isLeaf: node.isLeaf,
-            childIds: [],
-        })
-
-        if (node.parentId === null) {
-            rootId = node.id
-        }
-    }
-
-    // Build parent-child relationships
-    for (const node of nodes) {
-        if (node.parentId) {
-            const parent = nodeMap.get(node.parentId)
-            if (parent) {
-                parent.childIds.push(node.id)
-            }
-        }
-    }
-
-    if (!rootId) {
-        return { length: 0, isConvergent: false }
-    }
-
-    // Compute length using in-memory DFS
-    function getDepth(nodeId: string): number {
-        const node = nodeMap.get(nodeId)
-        if (!node || node.childIds.length === 0) {
-            return 0
-        }
-
-        const childDepths = node.childIds.map((childId) => getDepth(childId))
-        return 1 + Math.max(...childDepths)
-    }
-
-    const length = getDepth(rootId)
-
-    // Compute convergence in-memory
-    let isConvergent = false
-    for (const node of nodeMap.values()) {
-        // Count non-leaf children
-        const nonLeafChildren = node.childIds.filter((childId) => {
-            const child = nodeMap.get(childId)
-            return child && !child.isLeaf
-        })
-
-        if (nonLeafChildren.length >= 2) {
-            isConvergent = true
-            break
-        }
-    }
-
-    return { length, isConvergent }
-}
-
-/**
  * Loads a benchmark from a JSON.gz file.
  * Parses targets, creates molecules, benchmark targets, and routes.
  *
@@ -443,7 +390,7 @@ export async function loadBenchmarkFromFile(
                 const targetData = benchmarkData.targets[externalId]
 
                 // Get or create target molecule
-                const targetInchikey = targetData.inchi_key
+                const targetInchikey = targetData.inchikey
 
                 if (!targetInchikey) {
                     throw new Error(`Target ${externalId} is missing inchikey`)
@@ -473,8 +420,9 @@ export async function loadBenchmarkFromFile(
                 const acceptableRoutes = targetData.acceptable_routes
                 if (acceptableRoutes && acceptableRoutes.length > 0) {
                     const primaryRoute = acceptableRoutes[0]
-                    routeLength = primaryRoute.length ?? null
-                    isConvergent = primaryRoute.has_convergent_reaction ?? null
+                    const primaryProjection = routeProjection(primaryRoute)
+                    routeLength = primaryRoute.length ?? primaryProjection.route.length
+                    isConvergent = primaryRoute.has_convergent_reaction ?? primaryProjection.route.hasConvergentReaction
                 }
 
                 // Create benchmark target
@@ -485,7 +433,10 @@ export async function loadBenchmarkFromFile(
                         moleculeId: targetMol.id,
                         routeLength,
                         isConvergent,
-                        metadata: targetData.metadata ? JSON.stringify(targetData.metadata) : null,
+                        metadata:
+                            Object.keys(getAnnotations(targetData)).length > 0
+                                ? JSON.stringify(getAnnotations(targetData))
+                                : null,
                     },
                 })
 
@@ -495,14 +446,8 @@ export async function loadBenchmarkFromFile(
                         const routeData = targetData.acceptable_routes[routeIndex]
 
                         // Extract route properties from file
-                        const signature = routeData.signature || null
-
-                        // Enforce data quality: acceptable routes must have a signature for topology deduplication.
-                        if (!signature) {
-                            throw new Error(
-                                `Acceptable route at index ${routeIndex} for target ${externalId} is missing a route signature. Cannot ensure deduplication.`
-                            )
-                        }
+                        const projection = routeProjection(routeData)
+                        const signature = projection.route.signature
 
                         // Attempt to create route or reuse if exists (handles race conditions via unique constraints)
                         let routeId: string
@@ -530,10 +475,8 @@ export async function loadBenchmarkFromFile(
                                 routeLengthComputed = routeData.length
                                 routeIsConvergentComputed = routeData.has_convergent_reaction
                             } else {
-                                // Compute route properties (in-memory using single query)
-                                const computed = await computeRouteProperties(route.id, tx)
-                                routeLengthComputed = computed.length
-                                routeIsConvergentComputed = computed.isConvergent
+                                routeLengthComputed = projection.route.length
+                                routeIsConvergentComputed = projection.route.hasConvergentReaction
                             }
 
                             // Update route with final properties

--- a/src/lib/services/loaders/prediction-loader.service.ts
+++ b/src/lib/services/loaders/prediction-loader.service.ts
@@ -1,4 +1,6 @@
 import crypto from 'crypto'
+import { projectRetrocastRoute } from '@ischemist/routes'
+import type { RetrocastMolecule, RetrocastReaction, RetrocastRoute } from '@ischemist/routes'
 import { Prisma, ReliabilityCode } from '@prisma/client'
 
 import type { MetricResult, ModelStatistics, ReliabilityFlag, StratifiedMetric } from '@/types'
@@ -15,18 +17,18 @@ type DbClient = typeof prisma | Prisma.TransactionClient
 export interface PythonMolecule {
     smiles: string
     inchikey: string
-    synthesis_step: PythonReactionStep | null
-    metadata?: Record<string, unknown>
+    product_of?: PythonReactionStep | null
+    annotations?: Record<string, unknown>
     is_leaf?: boolean
 }
 
 interface PythonReactionStep {
     reactants: PythonMolecule[]
-    mapped_smiles?: string | null
+    mapped_reaction_smiles?: string | null
     template?: string | null
     reagents?: string[] | null
     solvents?: string[] | null
-    metadata?: Record<string, unknown>
+    annotations?: Record<string, unknown>
     is_convergent?: boolean
 }
 
@@ -34,41 +36,31 @@ export interface PythonRoute {
     target: PythonMolecule
     rank: number
     solvability?: Record<string, boolean>
-    metadata?: Record<string, unknown>
-    signature: string
+    annotations?: Record<string, unknown>
+    schema_version?: string
 }
 
-// Types for Python statistics data (snake_case)
-interface PythonMetricResult {
+interface RetrocastAnalysisMetric {
     value: number
-    ci_lower: number
-    ci_upper: number
-    n_samples: number
-    reliability: {
+    count: number
+    ci_low?: number
+    ci_high?: number
+    reliability?: {
         code: string
         message: string
     }
 }
 
-interface PythonStratifiedMetric {
-    metric_name: string
-    overall: PythonMetricResult
-    by_group?: Record<string, PythonMetricResult>
-}
-
-export interface PythonModelStatistics {
-    solvability: PythonStratifiedMetric
-    top_k_accuracy?: Record<string, PythonStratifiedMetric>
-    rank_distribution?: {
-        rank: number
-        probability: number
-    }[]
-    expected_rank?: number
-    // Runtime metrics (in seconds) from Python ModelStatistics
-    total_wall_time?: number | null
-    total_cpu_time?: number | null
-    mean_wall_time?: number | null
-    mean_cpu_time?: number | null
+export interface RetrocastAnalysis {
+    schema_version?: string
+    metrics: Record<string, RetrocastAnalysisMetric>
+    by_stratum?: Record<string, Record<string, RetrocastAnalysisMetric>>
+    runtime?: {
+        total_wall_time?: number | null
+        total_cpu_time?: number | null
+        mean_wall_time?: number | null
+        mean_cpu_time?: number | null
+    }
 }
 
 // ============================================================================
@@ -79,8 +71,9 @@ export interface PythonModelStatistics {
  * Computes route length (number of reaction steps).
  */
 export function computeRouteLength(root: PythonMolecule): number {
-    if (!root.synthesis_step) return 0
-    const childLengths = root.synthesis_step.reactants.map(computeRouteLength)
+    const step = getSynthesisStep(root)
+    if (!step) return 0
+    const childLengths = step.reactants.map(computeRouteLength)
     return 1 + Math.max(...childLengths, 0)
 }
 
@@ -96,12 +89,50 @@ export function computeRouteLength(root: PythonMolecule): number {
  * (`computeRouteProperties`): a node is convergent when it has ≥2 non-leaf children.
  */
 export function isRouteConvergent(root: PythonMolecule): boolean {
-    if (!root.synthesis_step) return false
-    const reactants = root.synthesis_step.reactants
+    const step = getSynthesisStep(root)
+    if (!step) return false
+    const reactants = step.reactants
     // Count non-leaf reactants (reactants that themselves have synthesis steps)
-    const nonLeafReactants = reactants.filter((r) => r.synthesis_step !== null)
+    const nonLeafReactants = reactants.filter((r) => getSynthesisStep(r) !== null)
     if (nonLeafReactants.length >= 2) return true
     return reactants.some(isRouteConvergent)
+}
+
+function getSynthesisStep(molecule: PythonMolecule): PythonReactionStep | null {
+    return molecule.product_of ?? null
+}
+
+function getAnnotations(value: { annotations?: Record<string, unknown> }): Record<string, unknown> {
+    return value.annotations ?? {}
+}
+
+function normalizeMoleculeForRetrocast(molecule: PythonMolecule): RetrocastMolecule {
+    const step = getSynthesisStep(molecule)
+    return {
+        smiles: molecule.smiles,
+        inchikey: molecule.inchikey,
+        ...(step ? { product_of: normalizeReactionForRetrocast(step) } : {}),
+        annotations: getAnnotations(molecule),
+    }
+}
+
+function normalizeReactionForRetrocast(step: PythonReactionStep): RetrocastReaction {
+    return {
+        reactants: step.reactants.map(normalizeMoleculeForRetrocast),
+        mapped_reaction_smiles: step.mapped_reaction_smiles ?? null,
+        template: step.template ?? null,
+        reagents: step.reagents ?? null,
+        solvents: step.solvents ?? null,
+        annotations: getAnnotations(step),
+    }
+}
+
+function normalizeRouteForRetrocast(route: PythonRoute): RetrocastRoute {
+    return {
+        target: normalizeMoleculeForRetrocast(route.target),
+        annotations: getAnnotations(route),
+        schema_version: '2',
+    }
 }
 
 /**
@@ -115,76 +146,93 @@ function computeReactionHash(step: PythonReactionStep, productInchikey: string):
     return crypto.createHash('sha256').update(content).digest('hex')
 }
 
-/**
- * Transforms Python snake_case statistics JSON to TypeScript camelCase.
- * Converts field names to match TypeScript ModelStatistics interface.
- *
- * @param pythonStats - Raw Python statistics object with snake_case keys
- * @returns ModelStatistics object with camelCase keys
- */
-export function transformPythonStatistics(pythonStats: PythonModelStatistics): ModelStatistics {
-    // Helper to transform a single metric result
-    const transformMetricResult = (pythonResult: PythonMetricResult): MetricResult => ({
-        value: pythonResult.value,
-        ciLower: pythonResult.ci_lower,
-        ciUpper: pythonResult.ci_upper,
-        nSamples: pythonResult.n_samples,
+function routeMetadata(route: PythonRoute): Record<string, unknown> | undefined {
+    const metadata = getAnnotations(route)
+    return Object.keys(metadata).length > 0 ? metadata : undefined
+}
+
+function metricResultFromAnalysisMetric(metric: RetrocastAnalysisMetric): MetricResult {
+    return {
+        value: metric.value,
+        ciLower: metric.ci_low ?? metric.value,
+        ciUpper: metric.ci_high ?? metric.value,
+        nSamples: metric.count,
         reliability: {
-            code: pythonResult.reliability.code as ReliabilityFlag['code'],
-            message: pythonResult.reliability.message,
+            code: (metric.reliability?.code ?? 'OK') as ReliabilityFlag['code'],
+            message: metric.reliability?.message ?? 'Reliable.',
         },
-    })
+    }
+}
 
-    // Helper to transform a stratified metric
-    const transformStratifiedMetric = (pythonMetric: PythonStratifiedMetric): StratifiedMetric => ({
-        metricName: pythonMetric.metric_name,
-        overall: transformMetricResult(pythonMetric.overall),
-        byGroup: Object.fromEntries(
-            Object.entries(pythonMetric.by_group || {}).map(([key, value]: [string, PythonMetricResult]) => [
-                parseInt(key, 10),
-                transformMetricResult(value),
-            ])
-        ),
-    })
+function metricKeyForSolvability(metrics: Record<string, RetrocastAnalysisMetric>): string {
+    const solvabilityKey = Object.keys(metrics).find((key) => /^solv_0\[.+\]_rate$/.test(key))
+    if (!solvabilityKey) {
+        throw new Error('RetroCast analysis is missing a solv_0[...]_rate metric')
+    }
+    return solvabilityKey
+}
 
-    // Transform the full statistics object
-    const result: ModelStatistics = {
-        solvability: transformStratifiedMetric(pythonStats.solvability),
-    }
+function topKFromMetricName(metricName: string): string | null {
+    const match = metricName.match(/^acceptable_reconstruction_top_(\d+)\[.+\]$/)
+    return match?.[1] ?? null
+}
 
-    // Transform top_k_accuracy if present
-    if (pythonStats.top_k_accuracy) {
-        result.topKAccuracy = Object.fromEntries(
-            Object.entries(pythonStats.top_k_accuracy).map(([k, metric]: [string, PythonStratifiedMetric]) => [
-                k,
-                transformStratifiedMetric(metric),
-            ])
-        )
-    }
+function stratumGroupKey(stratum: string): number | null {
+    const match = stratum.match(/\d+/)
+    return match ? parseInt(match[0], 10) : null
+}
 
-    // Transform optional fields if present
-    if (pythonStats.rank_distribution) {
-        result.rankDistribution = pythonStats.rank_distribution
-    }
-    if (pythonStats.expected_rank !== undefined) {
-        result.expectedRank = pythonStats.expected_rank
-    }
+/**
+ * Converts RetroCast v0.7 analysis.json.gz payloads into SynthArena's metric DTO.
+ */
+export function transformRetrocastAnalysis(analysis: RetrocastAnalysis): ModelStatistics {
+    const solvabilityKey = metricKeyForSolvability(analysis.metrics)
+    const solvabilityByGroup: Record<number, MetricResult> = {}
+    const topKAccuracy: Record<string, StratifiedMetric> = {}
 
-    // Transform runtime metrics (in seconds)
-    if (pythonStats.total_wall_time !== undefined && pythonStats.total_wall_time !== null) {
-        result.totalWallTime = pythonStats.total_wall_time
-    }
-    if (pythonStats.total_cpu_time !== undefined && pythonStats.total_cpu_time !== null) {
-        result.totalCpuTime = pythonStats.total_cpu_time
-    }
-    if (pythonStats.mean_wall_time !== undefined && pythonStats.mean_wall_time !== null) {
-        result.meanWallTime = pythonStats.mean_wall_time
-    }
-    if (pythonStats.mean_cpu_time !== undefined && pythonStats.mean_cpu_time !== null) {
-        result.meanCpuTime = pythonStats.mean_cpu_time
+    for (const [stratum, metrics] of Object.entries(analysis.by_stratum ?? {})) {
+        const groupKey = stratumGroupKey(stratum)
+        if (groupKey === null) continue
+
+        const solvabilityMetric = metrics[solvabilityKey]
+        if (solvabilityMetric) {
+            solvabilityByGroup[groupKey] = metricResultFromAnalysisMetric(solvabilityMetric)
+        }
+
+        for (const [metricName, metric] of Object.entries(metrics)) {
+            const topK = topKFromMetricName(metricName)
+            if (!topK) continue
+            topKAccuracy[topK] ??= {
+                metricName: `Top-${topK}`,
+                overall: metricResultFromAnalysisMetric(analysis.metrics[metricName] ?? metric),
+                byGroup: {},
+            }
+            topKAccuracy[topK].byGroup[groupKey] = metricResultFromAnalysisMetric(metric)
+        }
     }
 
-    return result
+    for (const [metricName, metric] of Object.entries(analysis.metrics)) {
+        const topK = topKFromMetricName(metricName)
+        if (!topK) continue
+        topKAccuracy[topK] ??= {
+            metricName: `Top-${topK}`,
+            overall: metricResultFromAnalysisMetric(metric),
+            byGroup: {},
+        }
+    }
+
+    return {
+        solvability: {
+            metricName: 'Solvability',
+            overall: metricResultFromAnalysisMetric(analysis.metrics[solvabilityKey]),
+            byGroup: solvabilityByGroup,
+        },
+        ...(Object.keys(topKAccuracy).length > 0 && { topKAccuracy }),
+        totalWallTime: analysis.runtime?.total_wall_time,
+        totalCpuTime: analysis.runtime?.total_cpu_time,
+        meanWallTime: analysis.runtime?.mean_wall_time,
+        meanCpuTime: analysis.runtime?.mean_cpu_time,
+    }
 }
 
 // ============================================================================
@@ -331,22 +379,24 @@ function collectRouteTreeData(
     const tempId = `temp-${tempIdCounter.value++}`
 
     // Determine if this is a leaf node
-    const isLeaf = !pythonMol.synthesis_step || pythonMol.is_leaf === true
+    const step = getSynthesisStep(pythonMol)
+    const isLeaf = !step || pythonMol.is_leaf === true
 
     // Compute reaction hash if not a leaf (uses InChIKeys for canonical identity)
     let reactionHash: string | null = null
-    if (pythonMol.synthesis_step) {
-        reactionHash = computeReactionHash(pythonMol.synthesis_step, pythonMol.inchikey)
+    if (step) {
+        reactionHash = computeReactionHash(step, pythonMol.inchikey)
     }
 
-    // Prepare node metadata (reagents, solvents, mapped_smiles)
+    // Prepare node metadata (reagents, solvents, mapped_reaction_smiles)
     let metadata: string | null = null
-    if (pythonMol.synthesis_step) {
+    if (step) {
         const metadataObj: Record<string, unknown> = {}
-        if (pythonMol.synthesis_step.reagents) metadataObj.reagents = pythonMol.synthesis_step.reagents
-        if (pythonMol.synthesis_step.solvents) metadataObj.solvents = pythonMol.synthesis_step.solvents
-        if (pythonMol.synthesis_step.mapped_smiles) metadataObj.mapped_smiles = pythonMol.synthesis_step.mapped_smiles
-        if (pythonMol.synthesis_step.metadata) metadataObj.python_metadata = pythonMol.synthesis_step.metadata
+        if (step.reagents) metadataObj.reagents = step.reagents
+        if (step.solvents) metadataObj.solvents = step.solvents
+        if (step.mapped_reaction_smiles) metadataObj.mapped_reaction_smiles = step.mapped_reaction_smiles
+        const stepAnnotations = getAnnotations(step)
+        if (Object.keys(stepAnnotations).length > 0) metadataObj.annotations = stepAnnotations
         if (Object.keys(metadataObj).length > 0) {
             metadata = JSON.stringify(metadataObj)
         }
@@ -360,14 +410,14 @@ function collectRouteTreeData(
         parentTempId,
         isLeaf,
         reactionHash,
-        template: pythonMol.synthesis_step?.template ?? null,
+        template: step?.template ?? null,
         metadata,
     }
     nodes.push(node)
 
     // Recursively process reactants
-    if (pythonMol.synthesis_step?.reactants) {
-        for (const reactant of pythonMol.synthesis_step.reactants) {
+    if (step?.reactants) {
+        for (const reactant of step.reactants) {
             collectRouteTreeData(reactant, routeId, tempId, molecules, nodes, tempIdCounter)
         }
     }
@@ -523,9 +573,10 @@ export async function createRouteFromPython(
 
     // Read route properties from Python JSON.
     // SynthArena treats route identity as topology-only and deduplicates by signature.
-    const signature = pythonRoute.signature
-    const length = computeRouteLength(pythonRoute.target)
-    const isConvergent = isRouteConvergent(pythonRoute.target)
+    const routeProjection = projectRetrocastRoute(normalizeRouteForRetrocast(pythonRoute))
+    const signature = routeProjection.route.signature
+    const length = routeProjection.route.length
+    const isConvergent = routeProjection.route.hasConvergentReaction
 
     // Wrap the entire create-or-reuse + prediction creation in a single transaction.
     // This eliminates two race conditions present in the original code:
@@ -589,7 +640,7 @@ export async function createRouteFromPython(
         }
 
         // Step 4: Create PredictionRoute junction record.
-        const metadata = pythonRoute.metadata ? JSON.stringify(pythonRoute.metadata) : null
+        const metadata = routeMetadata(pythonRoute)
 
         const predictionRoute = await tx.predictionRoute.create({
             data: {
@@ -597,7 +648,7 @@ export async function createRouteFromPython(
                 predictionRunId,
                 targetId,
                 rank: pythonRoute.rank,
-                metadata,
+                metadata: metadata ? JSON.stringify(metadata) : null,
             },
             select: { id: true },
         })

--- a/src/lib/services/loaders/prediction-loader.service.ts
+++ b/src/lib/services/loaders/prediction-loader.service.ts
@@ -71,7 +71,7 @@ export interface RetrocastAnalysis {
  * Computes route length (number of reaction steps).
  */
 export function computeRouteLength(root: PythonMolecule): number {
-    const step = getSynthesisStep(root)
+    const step = getProductOf(root)
     if (!step) return 0
     const childLengths = step.reactants.map(computeRouteLength)
     return 1 + Math.max(...childLengths, 0)
@@ -89,16 +89,16 @@ export function computeRouteLength(root: PythonMolecule): number {
  * (`computeRouteProperties`): a node is convergent when it has ≥2 non-leaf children.
  */
 export function isRouteConvergent(root: PythonMolecule): boolean {
-    const step = getSynthesisStep(root)
+    const step = getProductOf(root)
     if (!step) return false
     const reactants = step.reactants
     // Count non-leaf reactants (reactants that themselves have synthesis steps)
-    const nonLeafReactants = reactants.filter((r) => getSynthesisStep(r) !== null)
+    const nonLeafReactants = reactants.filter((r) => getProductOf(r) !== null)
     if (nonLeafReactants.length >= 2) return true
     return reactants.some(isRouteConvergent)
 }
 
-function getSynthesisStep(molecule: PythonMolecule): PythonReactionStep | null {
+function getProductOf(molecule: PythonMolecule): PythonReactionStep | null {
     return molecule.product_of ?? null
 }
 
@@ -107,7 +107,7 @@ function getAnnotations(value: { annotations?: Record<string, unknown> }): Recor
 }
 
 function normalizeMoleculeForRetrocast(molecule: PythonMolecule): RetrocastMolecule {
-    const step = getSynthesisStep(molecule)
+    const step = getProductOf(molecule)
     return {
         smiles: molecule.smiles,
         inchikey: molecule.inchikey,
@@ -164,7 +164,10 @@ function metricResultFromAnalysisMetric(metric: RetrocastAnalysisMetric): Metric
     }
 }
 
-function metricKeyForSolvability(metrics: Record<string, RetrocastAnalysisMetric>): string {
+function metricKeyForSolvability(metrics: Record<string, RetrocastAnalysisMetric> | undefined): string {
+    if (!metrics) {
+        throw new Error('RetroCast analysis is missing the metrics object')
+    }
     const solvabilityKey = Object.keys(metrics).find((key) => /^solv_0\[.+\]_rate$/.test(key))
     if (!solvabilityKey) {
         throw new Error('RetroCast analysis is missing a solv_0[...]_rate metric')
@@ -178,8 +181,8 @@ function topKFromMetricName(metricName: string): string | null {
 }
 
 function stratumGroupKey(stratum: string): number | null {
-    const match = stratum.match(/\d+/)
-    return match ? parseInt(match[0], 10) : null
+    const match = stratum.match(/^(?:depth|route_length)[ _-](\d+)$/)
+    return match ? parseInt(match[1], 10) : null
 }
 
 /**
@@ -379,7 +382,7 @@ function collectRouteTreeData(
     const tempId = `temp-${tempIdCounter.value++}`
 
     // Determine if this is a leaf node
-    const step = getSynthesisStep(pythonMol)
+    const step = getProductOf(pythonMol)
     const isLeaf = !step || pythonMol.is_leaf === true
 
     // Compute reaction hash if not a leaf (uses InChIKeys for canonical identity)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -188,7 +188,7 @@ interface ReactionStep {
     id: string
     reactionHash: string
     template: string | null
-    metadata: string | null // JSON: reagents, solvents, mapped_smiles
+    metadata: string | null // JSON: reagents, solvents, mapped_reaction_smiles
 }
 
 /**

--- a/tests/helpers/factories.ts
+++ b/tests/helpers/factories.ts
@@ -53,7 +53,7 @@ export function makeLeafMolecule(smiles: string = 'C'): PythonMolecule {
     return {
         smiles,
         inchikey: syntheticInchiKey(smiles),
-        synthesis_step: null,
+        product_of: null,
         is_leaf: true,
     }
 }
@@ -75,17 +75,13 @@ export function makeLinearPythonRoute(depth: number, rank: number = 1): PythonRo
         current = {
             smiles: productSmiles,
             inchikey: syntheticInchiKey(productSmiles),
-            synthesis_step: { reactants: [current] },
+            product_of: { reactants: [current] },
         }
     }
-
-    const treeJson = JSON.stringify(current)
-    const signature = crypto.createHash('sha256').update(`sig-${treeJson}`).digest('hex')
 
     return {
         target: current,
         rank,
-        signature,
     }
 }
 
@@ -110,7 +106,7 @@ export function makeConvergentPythonRoute(depth: number, rank: number = 1): Pyth
         branch1 = {
             smiles,
             inchikey: syntheticInchiKey(`branch1_${smiles}`),
-            synthesis_step: { reactants: [branch1] },
+            product_of: { reactants: [branch1] },
         }
     }
 
@@ -121,7 +117,7 @@ export function makeConvergentPythonRoute(depth: number, rank: number = 1): Pyth
         branch2 = {
             smiles,
             inchikey: syntheticInchiKey(`branch2_${smiles}`),
-            synthesis_step: { reactants: [branch2] },
+            product_of: { reactants: [branch2] },
         }
     }
 
@@ -130,16 +126,12 @@ export function makeConvergentPythonRoute(depth: number, rank: number = 1): Pyth
     const final: PythonMolecule = {
         smiles: finalSmiles,
         inchikey: syntheticInchiKey(finalSmiles),
-        synthesis_step: { reactants: [branch1, branch2] },
+        product_of: { reactants: [branch1, branch2] },
     }
-
-    const treeJson = JSON.stringify(final)
-    const signature = crypto.createHash('sha256').update(`sig-${treeJson}`).digest('hex')
 
     return {
         target: final,
         rank,
-        signature,
     }
 }
 
@@ -160,7 +152,7 @@ export function makeBinaryTreePythonRoute(depth: number, rank: number = 1): Pyth
             return {
                 smiles: 'C',
                 inchikey: syntheticInchiKey(`leaf_${leafCounter}`),
-                synthesis_step: null,
+                product_of: null,
                 is_leaf: true,
             }
         }
@@ -172,18 +164,14 @@ export function makeBinaryTreePythonRoute(depth: number, rank: number = 1): Pyth
         return {
             smiles: productSmiles,
             inchikey: syntheticInchiKey(`node_${currentDepth}_${leafCounter}`),
-            synthesis_step: { reactants: [left, right] },
+            product_of: { reactants: [left, right] },
         }
     }
 
     const target = buildTree(depth)
-    const treeJson = JSON.stringify(target)
-    const signature = crypto.createHash('sha256').update(`sig-${treeJson}`).digest('hex')
-
     return {
         target,
         rank,
-        signature,
     }
 }
 
@@ -216,7 +204,7 @@ export function pythonMoleculeToFlatNodes(
     parentId: string | null = null
 ): FlatNode[] {
     const nodeId = nextNodeId()
-    const isLeaf = !mol.synthesis_step
+    const isLeaf = !mol.product_of
 
     const node: FlatNode = {
         id: nodeId,
@@ -235,8 +223,8 @@ export function pythonMoleculeToFlatNodes(
 
     const result: FlatNode[] = [node]
 
-    if (mol.synthesis_step) {
-        for (const reactant of mol.synthesis_step.reactants) {
+    if (mol.product_of) {
+        for (const reactant of mol.product_of.reactants) {
             result.push(...pythonMoleculeToFlatNodes(reactant, routeId, nodeId))
         }
     }
@@ -248,24 +236,24 @@ export function pythonMoleculeToFlatNodes(
  * Count total nodes in a PythonMolecule tree.
  */
 export function countPythonMoleculeNodes(mol: PythonMolecule): number {
-    if (!mol.synthesis_step) return 1
-    return 1 + mol.synthesis_step.reactants.reduce((sum, r) => sum + countPythonMoleculeNodes(r), 0)
+    if (!mol.product_of) return 1
+    return 1 + mol.product_of.reactants.reduce((sum, r) => sum + countPythonMoleculeNodes(r), 0)
 }
 
 /**
  * Count leaf nodes in a PythonMolecule tree.
  */
 export function countLeafNodes(mol: PythonMolecule): number {
-    if (!mol.synthesis_step) return 1
-    return mol.synthesis_step.reactants.reduce((sum, r) => sum + countLeafNodes(r), 0)
+    if (!mol.product_of) return 1
+    return mol.product_of.reactants.reduce((sum, r) => sum + countLeafNodes(r), 0)
 }
 
 /**
  * Compute expected depth of a PythonMolecule tree (number of reaction steps on longest path).
  */
 export function computeExpectedDepth(mol: PythonMolecule): number {
-    if (!mol.synthesis_step) return 0
-    const childDepths = mol.synthesis_step.reactants.map(computeExpectedDepth)
+    if (!mol.product_of) return 0
+    const childDepths = mol.product_of.reactants.map(computeExpectedDepth)
     return 1 + Math.max(...childDepths, 0)
 }
 
@@ -311,6 +299,8 @@ async function createModelFamily(overrides: { algorithmId: string; name?: string
 /**
  * Create a ModelInstance record with sensible defaults.
  */
+let modelInstanceCounter = 0
+
 async function createModelInstance(overrides: {
     modelFamilyId: string
     slug?: string
@@ -322,7 +312,7 @@ async function createModelInstance(overrides: {
     return prisma.modelInstance.create({
         data: {
             modelFamilyId: overrides.modelFamilyId,
-            slug: overrides.slug ?? `test-model-${Date.now()}`,
+            slug: overrides.slug ?? `test-model-${Date.now()}-${++modelInstanceCounter}`,
             versionMajor: overrides.versionMajor ?? 1,
             versionMinor: overrides.versionMinor ?? 0,
             versionPatch: overrides.versionPatch ?? 0,
@@ -451,16 +441,15 @@ export function createTestCsvFile(
 interface TestBenchmarkTarget {
     id: string
     smiles: string
-    inchi_key: string
-    metadata?: Record<string, unknown>
+    inchikey: string
+    annotations?: Record<string, unknown>
     acceptable_routes: Array<{
         target: PythonMolecule
         rank: number
-        signature?: string
         length?: number
         has_convergent_reaction?: boolean
         solvability?: Record<string, boolean>
-        metadata?: Record<string, unknown>
+        annotations?: Record<string, unknown>
     }>
 }
 

--- a/tests/lib/services/loaders/benchmark-loader.integration.test.ts
+++ b/tests/lib/services/loaders/benchmark-loader.integration.test.ts
@@ -36,7 +36,6 @@ function makeBenchmarkTarget(
     acceptableRoutes: Array<{
         target: ReturnType<typeof makeLeafMolecule>
         rank: number
-        signature?: string
         length?: number
         has_convergent_reaction?: boolean
     }> = []
@@ -44,7 +43,7 @@ function makeBenchmarkTarget(
     return {
         id,
         smiles,
-        inchi_key: syntheticInchiKey(smiles),
+        inchikey: syntheticInchiKey(smiles),
         acceptable_routes: acceptableRoutes,
     }
 }
@@ -96,12 +95,11 @@ describe('loadBenchmarkFromFile', () => {
                 't-001': {
                     id: 't-001',
                     smiles: route.target.smiles,
-                    inchi_key: syntheticInchiKey(route.target.smiles),
+                    inchikey: syntheticInchiKey(route.target.smiles),
                     acceptable_routes: [
                         {
                             target: route.target,
                             rank: 1,
-                            signature: route.signature,
                             length: 2,
                             has_convergent_reaction: false,
                         },
@@ -119,7 +117,7 @@ describe('loadBenchmarkFromFile', () => {
         // Verify Route in DB
         const routes = await prisma.route.findMany()
         expect(routes).toHaveLength(1)
-        expect(routes[0].signature).toBe(route.signature)
+        expect(routes[0].signature).toBeTruthy()
         expect(routes[0].length).toBe(2)
         expect(routes[0].isConvergent).toBe(false)
 
@@ -153,12 +151,11 @@ describe('loadBenchmarkFromFile', () => {
                 't-001': {
                     id: 't-001',
                     smiles: target1Smiles,
-                    inchi_key: syntheticInchiKey(target1Smiles),
+                    inchikey: syntheticInchiKey(target1Smiles),
                     acceptable_routes: [
                         {
                             target: route.target,
                             rank: 1,
-                            signature: route.signature,
                             length: 1,
                             has_convergent_reaction: false,
                         },
@@ -167,12 +164,11 @@ describe('loadBenchmarkFromFile', () => {
                 't-002': {
                     id: 't-002',
                     smiles: target2Smiles,
-                    inchi_key: syntheticInchiKey(target2Smiles),
+                    inchikey: syntheticInchiKey(target2Smiles),
                     acceptable_routes: [
                         {
                             target: route.target,
                             rank: 1,
-                            signature: route.signature,
                             length: 1,
                             has_convergent_reaction: false,
                         },
@@ -197,7 +193,7 @@ describe('loadBenchmarkFromFile', () => {
         expect(acceptableRoutes).toHaveLength(2)
     })
 
-    it('throws when acceptable route is missing signature', async () => {
+    it('computes route signatures from v0.7 route payloads', async () => {
         const stock = await createStock({ name: 'bench-stock-missing-hash' })
         const benchmark = await createBenchmarkSet({ stockId: stock.id, name: 'bench-missing' })
 
@@ -209,12 +205,12 @@ describe('loadBenchmarkFromFile', () => {
                 't-001': {
                     id: 't-001',
                     smiles: route.target.smiles,
-                    inchi_key: syntheticInchiKey(route.target.smiles),
+                    inchikey: syntheticInchiKey(route.target.smiles),
                     acceptable_routes: [
                         {
                             target: route.target,
                             rank: 1,
-                            // Missing signature!
+                            // Signature is computed from the route tree.
                         },
                     ],
                 },
@@ -222,9 +218,11 @@ describe('loadBenchmarkFromFile', () => {
         }
         const filePath = createTestBenchmarkGzFile(data)
 
-        await expect(loadBenchmarkFromFile(filePath, benchmark.id, 'bench-missing')).rejects.toThrow(
-            'Cannot ensure deduplication'
-        )
+        const result = await loadBenchmarkFromFile(filePath, benchmark.id, 'bench-missing')
+
+        expect(result.routesCreated).toBe(1)
+        const routeCount = await prisma.route.count()
+        expect(routeCount).toBe(1)
     })
 
     it('uses file data for route length and isConvergent when present', async () => {
@@ -239,12 +237,11 @@ describe('loadBenchmarkFromFile', () => {
                 't-001': {
                     id: 't-001',
                     smiles: route.target.smiles,
-                    inchi_key: syntheticInchiKey(route.target.smiles),
+                    inchikey: syntheticInchiKey(route.target.smiles),
                     acceptable_routes: [
                         {
                             target: route.target,
                             rank: 1,
-                            signature: route.signature,
                             length: 3,
                             has_convergent_reaction: false,
                         },
@@ -256,7 +253,7 @@ describe('loadBenchmarkFromFile', () => {
 
         await loadBenchmarkFromFile(filePath, benchmark.id, 'bench-props')
 
-        const dbRoute = await prisma.route.findUnique({ where: { signature: route.signature } })
+        const dbRoute = await prisma.route.findFirst()
         expect(dbRoute!.length).toBe(3)
         expect(dbRoute!.isConvergent).toBe(false)
     })
@@ -273,12 +270,11 @@ describe('loadBenchmarkFromFile', () => {
                 't-001': {
                     id: 't-001',
                     smiles: route.target.smiles,
-                    inchi_key: syntheticInchiKey(route.target.smiles),
+                    inchikey: syntheticInchiKey(route.target.smiles),
                     acceptable_routes: [
                         {
                             target: route.target,
                             rank: 1,
-                            signature: route.signature,
                             // No length or has_convergent_reaction — must be computed
                         },
                     ],
@@ -289,7 +285,7 @@ describe('loadBenchmarkFromFile', () => {
 
         await loadBenchmarkFromFile(filePath, benchmark.id, 'bench-compute')
 
-        const dbRoute = await prisma.route.findUnique({ where: { signature: route.signature } })
+        const dbRoute = await prisma.route.findFirst()
         expect(dbRoute!.length).toBe(2)
         expect(dbRoute!.isConvergent).toBe(true)
     })
@@ -314,12 +310,11 @@ describe('loadBenchmarkFromFile', () => {
                 't-001': {
                     id: 't-001',
                     smiles: route.target.smiles,
-                    inchi_key: syntheticInchiKey(route.target.smiles),
+                    inchikey: syntheticInchiKey(route.target.smiles),
                     acceptable_routes: [
                         {
                             target: route.target,
                             rank: 1,
-                            signature: route.signature,
                             length: 1,
                             has_convergent_reaction: false,
                         },
@@ -355,12 +350,11 @@ describe('loadBenchmarkFromFile', () => {
                 't-001': {
                     id: 't-001',
                     smiles: route.target.smiles,
-                    inchi_key: syntheticInchiKey(route.target.smiles),
+                    inchikey: syntheticInchiKey(route.target.smiles),
                     acceptable_routes: [
                         {
                             target: route.target,
                             rank: 1,
-                            signature: route.signature,
                             length: 2,
                             has_convergent_reaction: false,
                         },
@@ -413,12 +407,11 @@ describe('loadBenchmarkFromFile', () => {
                 't-001': {
                     id: 't-001',
                     smiles: route.target.smiles,
-                    inchi_key: syntheticInchiKey(route.target.smiles),
+                    inchikey: syntheticInchiKey(route.target.smiles),
                     acceptable_routes: [
                         {
                             target: route.target,
                             rank: 1,
-                            signature: route.signature,
                             length: 2,
                             has_convergent_reaction: true,
                         },
@@ -450,19 +443,17 @@ describe('loadBenchmarkFromFile', () => {
                 't-001': {
                     id: 't-001',
                     smiles: carbonChainSmiles(10),
-                    inchi_key: syntheticInchiKey(carbonChainSmiles(10)),
+                    inchikey: syntheticInchiKey(carbonChainSmiles(10)),
                     acceptable_routes: [
                         {
                             target: route1.target,
                             rank: 1,
-                            signature: route1.signature,
                             length: 1,
                             has_convergent_reaction: false,
                         },
                         {
                             target: route2.target,
                             rank: 2,
-                            signature: route2.signature,
                             length: 3,
                             has_convergent_reaction: false,
                         },
@@ -508,12 +499,11 @@ describe('loadBenchmarkFromFile', () => {
                 't-a': {
                     id: 't-a',
                     smiles: carbonChainSmiles(10),
-                    inchi_key: syntheticInchiKey(carbonChainSmiles(10)),
+                    inchikey: syntheticInchiKey(carbonChainSmiles(10)),
                     acceptable_routes: [
                         {
                             target: route.target,
                             rank: 1,
-                            signature: route.signature,
                             length: 1,
                             has_convergent_reaction: false,
                         },
@@ -528,7 +518,7 @@ describe('loadBenchmarkFromFile', () => {
         const bench1Updated = await prisma.benchmarkSet.findUnique({ where: { id: benchmark1.id } })
         expect(bench1Updated!.hasAcceptableRoutes).toBe(true)
 
-        // Second benchmark: uses the SAME route signature — routesCreated will be 0 (reused)
+        // Second benchmark: uses the same route tree — routesCreated will be 0 (reused)
         // but hasAcceptableRoutes must still be set to true.
         const benchmark2 = await createBenchmarkSet({ stockId: stock.id, name: 'bench-reuse-flag-2' })
         const data2 = {
@@ -537,12 +527,11 @@ describe('loadBenchmarkFromFile', () => {
                 't-b': {
                     id: 't-b',
                     smiles: carbonChainSmiles(11),
-                    inchi_key: syntheticInchiKey(carbonChainSmiles(11)),
+                    inchikey: syntheticInchiKey(carbonChainSmiles(11)),
                     acceptable_routes: [
                         {
                             target: route.target, // same route tree as above
                             rank: 1,
-                            signature: route.signature, // same signature → route will be reused
                             length: 1,
                             has_convergent_reaction: false,
                         },

--- a/tests/lib/services/loaders/benchmark-loader.integration.test.ts
+++ b/tests/lib/services/loaders/benchmark-loader.integration.test.ts
@@ -48,6 +48,22 @@ function makeBenchmarkTarget(
     }
 }
 
+async function findAcceptableRouteForTarget(benchmarkSetId: string, targetId: string) {
+    const target = await prisma.benchmarkTarget.findUnique({
+        where: { benchmarkSetId_targetId: { benchmarkSetId, targetId } },
+        include: {
+            acceptableRoutes: {
+                include: { route: true },
+                orderBy: { routeIndex: 'asc' },
+            },
+        },
+    })
+
+    expect(target).not.toBeNull()
+    expect(target!.acceptableRoutes).toHaveLength(1)
+    return target!.acceptableRoutes[0]!.route
+}
+
 // ============================================================================
 // loadBenchmarkFromFile — basic target loading
 // ============================================================================
@@ -221,8 +237,10 @@ describe('loadBenchmarkFromFile', () => {
         const result = await loadBenchmarkFromFile(filePath, benchmark.id, 'bench-missing')
 
         expect(result.routesCreated).toBe(1)
-        const routeCount = await prisma.route.count()
-        expect(routeCount).toBe(1)
+        const dbRoute = await findAcceptableRouteForTarget(benchmark.id, 't-001')
+        expect(dbRoute.signature).toBeTruthy()
+        expect(dbRoute.length).toBe(1)
+        expect(dbRoute.isConvergent).toBe(false)
     })
 
     it('uses file data for route length and isConvergent when present', async () => {
@@ -253,9 +271,9 @@ describe('loadBenchmarkFromFile', () => {
 
         await loadBenchmarkFromFile(filePath, benchmark.id, 'bench-props')
 
-        const dbRoute = await prisma.route.findFirst()
-        expect(dbRoute!.length).toBe(3)
-        expect(dbRoute!.isConvergent).toBe(false)
+        const dbRoute = await findAcceptableRouteForTarget(benchmark.id, 't-001')
+        expect(dbRoute.length).toBe(3)
+        expect(dbRoute.isConvergent).toBe(false)
     })
 
     it('computes route properties when not present in file data', async () => {
@@ -285,9 +303,9 @@ describe('loadBenchmarkFromFile', () => {
 
         await loadBenchmarkFromFile(filePath, benchmark.id, 'bench-compute')
 
-        const dbRoute = await prisma.route.findFirst()
-        expect(dbRoute!.length).toBe(2)
-        expect(dbRoute!.isConvergent).toBe(true)
+        const dbRoute = await findAcceptableRouteForTarget(benchmark.id, 't-001')
+        expect(dbRoute.length).toBe(2)
+        expect(dbRoute.isConvergent).toBe(true)
     })
 
     it('reuses molecules already in the database (e.g., from stock loading)', async () => {

--- a/tests/lib/services/loaders/loader-roundtrip.integration.test.ts
+++ b/tests/lib/services/loaders/loader-roundtrip.integration.test.ts
@@ -75,12 +75,11 @@ describe('loader roundtrip', () => {
                 'rt-001': {
                     id: 'rt-001',
                     smiles: benchRoute.target.smiles,
-                    inchi_key: syntheticInchiKey(benchRoute.target.smiles),
+                    inchikey: syntheticInchiKey(benchRoute.target.smiles),
                     acceptable_routes: [
                         {
                             target: benchRoute.target,
                             rank: 1,
-                            signature: benchRoute.signature,
                             length: 2,
                             has_convergent_reaction: false,
                         },
@@ -187,7 +186,7 @@ describe('loader roundtrip', () => {
                 'tm-001': {
                     id: 'tm-001',
                     smiles: targetSmiles,
-                    inchi_key: syntheticInchiKey(targetSmiles),
+                    inchikey: syntheticInchiKey(targetSmiles),
                     acceptable_routes: [],
                 },
             },
@@ -257,12 +256,11 @@ describe('loader roundtrip', () => {
                 'conv-001': {
                     id: 'conv-001',
                     smiles: convergentRoute.target.smiles,
-                    inchi_key: syntheticInchiKey(convergentRoute.target.smiles),
+                    inchikey: syntheticInchiKey(convergentRoute.target.smiles),
                     acceptable_routes: [
                         {
                             target: convergentRoute.target,
                             rank: 1,
-                            signature: convergentRoute.signature,
                             // Omit length & has_convergent_reaction — force benchmark-loader to compute them
                         },
                     ],

--- a/tests/lib/services/loaders/prediction-loader.integration.test.ts
+++ b/tests/lib/services/loaders/prediction-loader.integration.test.ts
@@ -163,7 +163,7 @@ describe('createRouteFromPython', () => {
 
         // Verify Route in DB
         const dbRoute = await prisma.route.findUnique({ where: { id: result.routeId } })
-        expect(dbRoute!.signature).toBe(pyRoute.signature)
+        expect(dbRoute!.signature).toBeTruthy()
         expect(dbRoute!.length).toBe(2)
         expect(dbRoute!.isConvergent).toBe(false)
 
@@ -176,6 +176,57 @@ describe('createRouteFromPython', () => {
         expect(predRoute!.routeId).toBe(result.routeId)
         expect(predRoute!.predictionRunId).toBe(run.id)
         expect(predRoute!.targetId).toBe(target.id)
+    })
+
+    it('creates a route from RetroCast v0.7 product_of payload without serialized signature', async () => {
+        const { instance, benchmark, target } = await setupPredictionContext()
+        const run = await createOrUpdatePredictionRun(benchmark.id, instance.id)
+        const route = {
+            rank: 1,
+            schema_version: '2',
+            annotations: { score: 0.7 },
+            target: {
+                smiles: 'CC',
+                inchikey: 'OTMSDBZUPAUEDD-UHFFFAOYSA-N',
+                product_of: {
+                    reactants: [
+                        {
+                            smiles: 'C',
+                            inchikey: 'VNWKTOKETHGBQD-UHFFFAOYSA-N',
+                            annotations: {},
+                        },
+                    ],
+                    mapped_reaction_smiles: 'C>>CC',
+                    template: 'template-a',
+                    annotations: { source: 'retrocast-v0.7-test' },
+                },
+                annotations: {},
+            },
+        }
+
+        const result = await createRouteFromPython(route, run.id, target.id)
+
+        const dbRoute = await prisma.route.findUnique({ where: { id: result.routeId } })
+        expect(dbRoute!.signature).toBeTruthy()
+        expect(dbRoute!.length).toBe(1)
+        expect(dbRoute!.isConvergent).toBe(false)
+
+        const nodes = await prisma.routeNode.findMany({ where: { routeId: result.routeId } })
+        expect(nodes).toHaveLength(2)
+
+        const predictionRoute = await prisma.predictionRoute.findUnique({ where: { id: result.predictionRouteId } })
+        expect(JSON.parse(predictionRoute!.metadata!)).toEqual({ score: 0.7 })
+
+        const reactionNode = await prisma.routeNode.findFirst({
+            where: { routeId: result.routeId, reactionStepId: { not: null } },
+            include: { reactionStep: true },
+        })
+        const reactionStep = reactionNode!.reactionStep
+        expect(reactionStep!.template).toBe('template-a')
+        expect(JSON.parse(reactionStep!.metadata!)).toMatchObject({
+            mapped_reaction_smiles: 'C>>CC',
+            annotations: { source: 'retrocast-v0.7-test' },
+        })
     })
 
     it('deduplicates route by signature — reuses Route, creates new PredictionRoute', async () => {

--- a/tests/lib/services/loaders/prediction-loader.test.ts
+++ b/tests/lib/services/loaders/prediction-loader.test.ts
@@ -284,4 +284,43 @@ describe('transformRetrocastAnalysis', () => {
         expect(result.totalWallTime).toBe(12)
         expect(result.meanCpuTime).toBe(1)
     })
+
+    it('throws a clear error when analysis metrics are missing', () => {
+        expect(() =>
+            transformRetrocastAnalysis({
+                schema_version: '2',
+                metrics: undefined as never,
+            })
+        ).toThrow('RetroCast analysis is missing the metrics object')
+    })
+
+    it('ignores strata without a route-length key', () => {
+        const result = transformRetrocastAnalysis({
+            schema_version: '2',
+            metrics: {
+                'solv_0[buyables-stock]_rate': {
+                    value: 0.8,
+                    count: 100,
+                },
+            },
+            by_stratum: {
+                top_10_route_length_5: {
+                    'solv_0[buyables-stock]_rate': {
+                        value: 0.9,
+                        count: 40,
+                    },
+                },
+                route_length_5: {
+                    'solv_0[buyables-stock]_rate': {
+                        value: 0.7,
+                        count: 20,
+                    },
+                },
+            },
+        })
+
+        expect(result.solvability.byGroup).toEqual({
+            5: expect.objectContaining({ value: 0.7 }),
+        })
+    })
 })

--- a/tests/lib/services/loaders/prediction-loader.test.ts
+++ b/tests/lib/services/loaders/prediction-loader.test.ts
@@ -1,18 +1,17 @@
 /**
  * Unit tests for pure functions in prediction-loader.service.ts
  *
- * Tests transformPythonStatistics (snake_case -> camelCase conversion),
- * computeRouteLength, and isRouteConvergent using carbon chain factories.
+ * Tests computeRouteLength, isRouteConvergent, and RetroCast analysis transforms.
  */
 
 import fc from 'fast-check'
 import { describe, expect, it } from 'vitest'
 
-import type { PythonModelStatistics, PythonMolecule } from '@/lib/services/loaders/prediction-loader.service'
+import type { PythonMolecule } from '@/lib/services/loaders/prediction-loader.service'
 import {
     computeRouteLength,
     isRouteConvergent,
-    transformPythonStatistics,
+    transformRetrocastAnalysis,
 } from '@/lib/services/loaders/prediction-loader.service'
 
 import {
@@ -31,6 +30,22 @@ describe('computeRouteLength', () => {
     it('returns 0 for a leaf molecule', () => {
         const leaf = makeLeafMolecule('C')
         expect(computeRouteLength(leaf)).toBe(0)
+    })
+
+    it('supports RetroCast v0.7 product_of route trees', () => {
+        const leaf = {
+            smiles: 'C',
+            inchikey: syntheticInchiKey('C'),
+            annotations: {},
+        }
+        const route: PythonMolecule = {
+            smiles: 'CC',
+            inchikey: syntheticInchiKey('CC'),
+            product_of: { reactants: [leaf] },
+            annotations: {},
+        }
+
+        expect(computeRouteLength(route)).toBe(1)
     })
 
     it.each([1, 2, 3, 4, 5, 6])('returns %d for a linear route of depth %d', (depth) => {
@@ -149,9 +164,29 @@ describe('isRouteConvergent', () => {
         const bimolecular: PythonMolecule = {
             smiles: 'CO',
             inchikey: syntheticInchiKey('CO'),
-            synthesis_step: { reactants: [leaf1, leaf2] },
+            product_of: { reactants: [leaf1, leaf2] },
         }
         expect(isRouteConvergent(bimolecular)).toBe(false)
+    })
+
+    it('detects convergence in RetroCast v0.7 product_of route trees', () => {
+        const left: PythonMolecule = {
+            smiles: 'CC',
+            inchikey: syntheticInchiKey('left'),
+            product_of: { reactants: [makeLeafMolecule('C')] },
+        }
+        const right: PythonMolecule = {
+            smiles: 'CO',
+            inchikey: syntheticInchiKey('right'),
+            product_of: { reactants: [makeLeafMolecule('O')] },
+        }
+        const root: PythonMolecule = {
+            smiles: 'CCO',
+            inchikey: syntheticInchiKey('root'),
+            product_of: { reactants: [left, right] },
+        }
+
+        expect(isRouteConvergent(root)).toBe(true)
     })
 
     it('detects convergence deep in a tree (two non-leaf branches merge)', () => {
@@ -171,242 +206,82 @@ describe('isRouteConvergent', () => {
         const branch1: PythonMolecule = {
             smiles: 'CC',
             inchikey: syntheticInchiKey('branch1_CC'),
-            synthesis_step: { reactants: [leaf_c] },
+            product_of: { reactants: [leaf_c] },
         }
         // Branch 2: O (synthesised from CC)
         const branch2: PythonMolecule = {
             smiles: 'O',
             inchikey: syntheticInchiKey('branch2_O'),
-            synthesis_step: { reactants: [leaf_c2] },
+            product_of: { reactants: [leaf_c2] },
         }
         // Convergent node: two NON-leaf branches merge
         const convergentNode: PythonMolecule = {
             smiles: 'CCO',
             inchikey: syntheticInchiKey('CCO'),
-            synthesis_step: { reactants: [branch1, branch2] },
+            product_of: { reactants: [branch1, branch2] },
         }
         // Linear step above the convergent node
         const linearAbove: PythonMolecule = {
             smiles: 'CCCO',
             inchikey: syntheticInchiKey('CCCO'),
-            synthesis_step: { reactants: [convergentNode] },
+            product_of: { reactants: [convergentNode] },
         }
 
         expect(isRouteConvergent(linearAbove)).toBe(true)
     })
 })
 
-// ============================================================================
-// transformPythonStatistics
-// ============================================================================
-
-describe('transformPythonStatistics', () => {
-    const minimalPythonStats: PythonModelStatistics = {
-        solvability: {
-            metric_name: 'solvability',
-            overall: {
-                value: 0.75,
-                ci_lower: 0.7,
-                ci_upper: 0.8,
-                n_samples: 100,
-                reliability: { code: 'OK', message: 'Sufficient samples' },
+describe('transformRetrocastAnalysis', () => {
+    it('maps v0.7 analysis metrics into solvability and top-k statistics', () => {
+        const result = transformRetrocastAnalysis({
+            schema_version: '2',
+            metrics: {
+                'solv_0[buyables-stock]_rate': {
+                    value: 0.8,
+                    count: 100,
+                    ci_low: 0.7,
+                    ci_high: 0.9,
+                    reliability: { code: 'OK', message: 'Reliable.' },
+                },
+                'acceptable_reconstruction_top_1[buyables-stock]': {
+                    value: 0.4,
+                    count: 100,
+                    ci_low: 0.3,
+                    ci_high: 0.5,
+                    reliability: { code: 'OK', message: 'Reliable.' },
+                },
             },
-        },
-    }
-
-    it('transforms snake_case to camelCase for solvability', () => {
-        const result = transformPythonStatistics(minimalPythonStats)
-
-        expect(result.solvability.metricName).toBe('solvability')
-        expect(result.solvability.overall.value).toBe(0.75)
-        expect(result.solvability.overall.ciLower).toBe(0.7)
-        expect(result.solvability.overall.ciUpper).toBe(0.8)
-        expect(result.solvability.overall.nSamples).toBe(100)
-        expect(result.solvability.overall.reliability.code).toBe('OK')
-        expect(result.solvability.overall.reliability.message).toBe('Sufficient samples')
-    })
-
-    it('preserves all numeric values exactly', () => {
-        const result = transformPythonStatistics(minimalPythonStats)
-
-        expect(result.solvability.overall.value).toStrictEqual(0.75)
-        expect(result.solvability.overall.ciLower).toStrictEqual(0.7)
-        expect(result.solvability.overall.ciUpper).toStrictEqual(0.8)
-        expect(result.solvability.overall.nSamples).toStrictEqual(100)
-    })
-
-    it('transforms top_k_accuracy when present', () => {
-        const statsWithTopK: PythonModelStatistics = {
-            ...minimalPythonStats,
-            top_k_accuracy: {
-                '1': {
-                    metric_name: 'Top-1',
-                    overall: {
-                        value: 0.3,
-                        ci_lower: 0.25,
-                        ci_upper: 0.35,
-                        n_samples: 100,
-                        reliability: { code: 'OK', message: 'OK' },
+            by_stratum: {
+                'depth 2': {
+                    'solv_0[buyables-stock]_rate': {
+                        value: 0.9,
+                        count: 40,
+                        ci_low: 0.8,
+                        ci_high: 1,
+                        reliability: { code: 'EXTREME_P', message: 'Boundary value.' },
                     },
-                    by_group: {
-                        '3': {
-                            value: 0.5,
-                            ci_lower: 0.4,
-                            ci_upper: 0.6,
-                            n_samples: 50,
-                            reliability: { code: 'OK', message: 'OK' },
-                        },
+                    'acceptable_reconstruction_top_1[buyables-stock]': {
+                        value: 0.5,
+                        count: 40,
+                        ci_low: 0.35,
+                        ci_high: 0.65,
+                        reliability: { code: 'OK', message: 'Reliable.' },
                     },
                 },
             },
-        }
+            runtime: {
+                total_wall_time: 12,
+                total_cpu_time: 10,
+                mean_wall_time: 1.2,
+                mean_cpu_time: 1,
+            },
+        })
 
-        const result = transformPythonStatistics(statsWithTopK)
-
-        expect(result.topKAccuracy).toBeDefined()
-        expect(result.topKAccuracy!['1'].metricName).toBe('Top-1')
-        expect(result.topKAccuracy!['1'].overall.value).toBe(0.3)
-
-        // Stratified by group
-        expect(result.topKAccuracy!['1'].byGroup[3]).toBeDefined()
-        expect(result.topKAccuracy!['1'].byGroup[3].value).toBe(0.5)
-    })
-
-    it('handles missing optional fields gracefully', () => {
-        const result = transformPythonStatistics(minimalPythonStats)
-
-        expect(result.topKAccuracy).toBeUndefined()
-        expect(result.rankDistribution).toBeUndefined()
-        expect(result.expectedRank).toBeUndefined()
-        expect(result.totalWallTime).toBeUndefined()
-        expect(result.totalCpuTime).toBeUndefined()
-        expect(result.meanWallTime).toBeUndefined()
-        expect(result.meanCpuTime).toBeUndefined()
-    })
-
-    it('transforms rank_distribution when present', () => {
-        const statsWithRank: PythonModelStatistics = {
-            ...minimalPythonStats,
-            rank_distribution: [
-                { rank: 1, probability: 0.6 },
-                { rank: 2, probability: 0.3 },
-                { rank: 3, probability: 0.1 },
-            ],
-            expected_rank: 1.5,
-        }
-
-        const result = transformPythonStatistics(statsWithRank)
-
-        expect(result.rankDistribution).toHaveLength(3)
-        expect(result.rankDistribution![0]).toEqual({ rank: 1, probability: 0.6 })
-        expect(result.expectedRank).toBe(1.5)
-    })
-
-    it('transforms runtime metrics when present', () => {
-        const statsWithRuntime: PythonModelStatistics = {
-            ...minimalPythonStats,
-            total_wall_time: 3600.5,
-            total_cpu_time: 7200.0,
-            mean_wall_time: 12.5,
-            mean_cpu_time: 25.0,
-        }
-
-        const result = transformPythonStatistics(statsWithRuntime)
-
-        expect(result.totalWallTime).toBe(3600.5)
-        expect(result.totalCpuTime).toBe(7200.0)
-        expect(result.meanWallTime).toBe(12.5)
-        expect(result.meanCpuTime).toBe(25.0)
-    })
-
-    it('treats null runtime metrics as absent', () => {
-        const statsWithNulls: PythonModelStatistics = {
-            ...minimalPythonStats,
-            total_wall_time: null,
-            total_cpu_time: null,
-            mean_wall_time: null,
-            mean_cpu_time: null,
-        }
-
-        const result = transformPythonStatistics(statsWithNulls)
-
-        expect(result.totalWallTime).toBeUndefined()
-        expect(result.totalCpuTime).toBeUndefined()
-        expect(result.meanWallTime).toBeUndefined()
-        expect(result.meanCpuTime).toBeUndefined()
-    })
-
-    it('(property) all solvability values are preserved through transformation', () => {
-        fc.assert(
-            fc.property(
-                fc.double({ min: 0, max: 1, noNaN: true }),
-                fc.double({ min: 0, max: 1, noNaN: true }),
-                fc.double({ min: 0, max: 1, noNaN: true }),
-                fc.integer({ min: 1, max: 10000 }),
-                (value, ciLower, ciUpper, nSamples) => {
-                    const stats: PythonModelStatistics = {
-                        solvability: {
-                            metric_name: 'solvability',
-                            overall: {
-                                value,
-                                ci_lower: ciLower,
-                                ci_upper: ciUpper,
-                                n_samples: nSamples,
-                                reliability: { code: 'OK', message: 'OK' },
-                            },
-                        },
-                    }
-
-                    const result = transformPythonStatistics(stats)
-
-                    return (
-                        result.solvability.overall.value === value &&
-                        result.solvability.overall.ciLower === ciLower &&
-                        result.solvability.overall.ciUpper === ciUpper &&
-                        result.solvability.overall.nSamples === nSamples
-                    )
-                }
-            )
-        )
-    })
-
-    it('(property) byGroup keys are parsed as integers', () => {
-        fc.assert(
-            fc.property(fc.array(fc.integer({ min: 1, max: 10 }), { minLength: 1, maxLength: 5 }), (groupKeys) => {
-                const uniqueKeys = [...new Set(groupKeys)]
-                const byGroup: Record<string, PythonModelStatistics['solvability']['overall']> = {}
-                for (const key of uniqueKeys) {
-                    byGroup[String(key)] = {
-                        value: 0.5,
-                        ci_lower: 0.4,
-                        ci_upper: 0.6,
-                        n_samples: 50,
-                        reliability: { code: 'OK', message: 'OK' },
-                    }
-                }
-
-                const stats: PythonModelStatistics = {
-                    solvability: {
-                        metric_name: 'solvability',
-                        overall: {
-                            value: 0.75,
-                            ci_lower: 0.7,
-                            ci_upper: 0.8,
-                            n_samples: 100,
-                            reliability: { code: 'OK', message: 'OK' },
-                        },
-                        by_group: byGroup,
-                    },
-                }
-
-                const result = transformPythonStatistics(stats)
-
-                // All group keys should be numeric
-                for (const key of Object.keys(result.solvability.byGroup)) {
-                    if (isNaN(Number(key))) return false
-                }
-                return Object.keys(result.solvability.byGroup).length === uniqueKeys.length
-            })
-        )
+        expect(result.solvability.overall.value).toBe(0.8)
+        expect(result.solvability.byGroup[2].value).toBe(0.9)
+        expect(result.topKAccuracy?.['1'].overall.value).toBe(0.4)
+        expect(result.topKAccuracy?.['1'].byGroup[2].value).toBe(0.5)
+        expect(result.totalWallTime).toBe(12)
+        expect(result.meanCpuTime).toBe(1)
     })
 })

--- a/tests/lib/services/view/leaderboard.integration.test.ts
+++ b/tests/lib/services/view/leaderboard.integration.test.ts
@@ -79,12 +79,11 @@ async function setupLeaderboardContext(label: string) {
             [`${label}-t-001`]: {
                 id: `${label}-t-001`,
                 smiles: targetSmiles,
-                inchi_key: syntheticInchiKey(targetSmiles),
+                inchikey: syntheticInchiKey(targetSmiles),
                 acceptable_routes: [
                     {
                         target: route.target,
                         rank: 1,
-                        signature: route.signature,
                         length: 2,
                         has_convergent_reaction: false,
                     },

--- a/tests/lib/tree-builder/route-tree.test.ts
+++ b/tests/lib/tree-builder/route-tree.test.ts
@@ -52,7 +52,7 @@ describe('buildRouteTree', () => {
             const nodes = pythonMoleculeToFlatNodes({
                 smiles: 'C',
                 inchikey: 'TEST-INCHIKEY-1',
-                synthesis_step: null,
+                product_of: null,
             })
 
             const tree = buildRouteTree(nodes)
@@ -69,7 +69,7 @@ describe('buildRouteTree', () => {
             const nodes = pythonMoleculeToFlatNodes({
                 smiles: 'C',
                 inchikey: 'TEST',
-                synthesis_step: null,
+                product_of: null,
             })
             // Corrupt the data: give root a parent
             nodes[0].parentId = 'fake-parent'


### PR DESCRIPTION
## why

retrocast v0.7 moved the route artifacts onto a stricter schema, with route trees expressed through `product_of`, reaction mapping stored as `mapped_reaction_smiles`, and artifact outputs renamed around candidates/evaluation/analysis. syntharena still accepted the old shapes in several loader paths, which kept the ingest boundary ambiguous and made it too easy to silently load stale data.

## what changed

- upgraded `@ischemist/routes` and `@ischemist/route-viewer` to `0.1.0`
- made benchmark and prediction loaders consume the v0.7 schema directly
- removed old-schema compatibility paths, including `synthesis_step`, `mapped_smiles`, `routes.json.gz`, and `statistics.json.gz`
- moved route signature/length/convergence derivation through `@ischemist/routes`
- updated docs and tests around `candidates.json.gz`, `evaluation.json.gz`, and `analysis.json.gz`

## risk

this is a data-boundary change. old retrocast exports now fail instead of being translated, intentionally. the main risk is ingest breakage for any unpublished artifacts still using the pre-v0.7 filenames or tree fields; that is preferable to preserving two source-of-truth schemas.

`ischemist.toml` is included because the requested scope was the full worktree.

## verification

- `git diff --check`
- `pnpm check-types`
- `pnpm lint`
- `pnpm test:run` — 14 files passed, 291 tests passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ischemist/codesmith/syntharena/pr/84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783902414&installation_id=125602297&pr_number=84&repository=ischemist%2Fsyntharena&return_to=https%3A%2F%2Fgithub.com%2Fischemist%2Fsyntharena%2Fpull%2F84&signature=f005ba06d74fd71cce27224a7e112aa27ae76f503a71487ad2a1c4dc015f90b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for RetroCast-generated candidates and analysis JSON artifacts in the data processing pipeline

* **Documentation**
  * Updated README and setup guide with new artifact file paths and format requirements

* **Chores**
  * Updated dependencies: `@ischemist/route-viewer` (0.0.7 → 0.1.0), `@ischemist/routes` (0.0.4 → 0.1.0)
  * Configuration adjustments for practices setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates the ingest layer from the pre-v0.7 retrocast schema to the strict v0.7 shapes: `product_of` replaces `synthesis_step`, `mapped_reaction_smiles` replaces `mapped_smiles`, `candidates.json.gz`/`analysis.json.gz` replace `routes.json.gz`/`statistics.json.gz`, and route signatures/lengths/convergence are now computed through `@ischemist/routes@0.1.0` instead of inline graph traversal.

- Removes all old-schema compatibility paths; old retrocast exports will fail loudly at ingest, eliminating silent stale-data ingestion.
- `transformRetrocastAnalysis` replaces `transformPythonStatistics`, adapting the `solv_0[…]_rate` / `acceptable_reconstruction_top_N[…]` metric key convention from v0.7 analysis artifacts.
- Stratification source shifts from evaluation-file fields to the `BenchmarkTarget` database record (`routeLength` / `isConvergent`), requiring the benchmark to be loaded before evaluations.

<h3>Confidence Score: 4/5</h3>

Safe to merge for fresh retrocast v0.7 data; old export consumers will break intentionally, which is the stated goal.

The ingest boundary change is clean and the test suite covers the main v0.7 paths (291 tests passing). The one new finding affects an edge case in transformRetrocastAnalysis where a top-k overall metric is absent from analysis.metrics — harmless for well-formed v0.7 payloads but a latent ordering-dependent gap.

src/lib/services/loaders/prediction-loader.service.ts (transformRetrocastAnalysis top-k overall initialization) and scripts/load-predictions.ts (candidateIsSolved edge cases noted in prior review rounds)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/lib/services/loaders/prediction-loader.service.ts | Core schema migration: replaces synthesis_step/mapped_smiles/signature fields with product_of/mapped_reaction_smiles/projectRetrocastRoute; adds transformRetrocastAnalysis for v0.7 analysis payloads |
| src/lib/services/loaders/benchmark-loader.service.ts | Migrates to v0.7 schema (inchi_key to inchikey, synthesis_step to product_of, metadata to annotations), replaces in-memory computeRouteProperties with projectRetrocastRoute from @ischemist/routes |
| scripts/load-predictions.ts | Switches from routes.json.gz to candidates.json.gz, EvaluationFile to RetrocastEvaluationArtifact, statistics to analysis; adds routeFromCandidate/candidateIsSolved adapters for v0.7 evaluation shape |
| tests/lib/services/loaders/prediction-loader.test.ts | Replaces transformPythonStatistics tests with transformRetrocastAnalysis tests; adds product_of v0.7 cases for computeRouteLength/isRouteConvergent |
| tests/helpers/factories.ts | Updates all factory helpers from synthesis_step/inchi_key/signature fields to product_of/inchikey; removes manual signature computation now delegated to @ischemist/routes |
| tests/lib/services/loaders/benchmark-loader.integration.test.ts | Updates inchi_key to inchikey and removes explicit signatures from test fixtures; renames the throws-on-missing-signature test to verify signatures are computed from tree topology |
| prisma/schema.prisma | Comment-only change: updates metadata field description from mapped_smiles to mapped_reaction_smiles to match v0.7 field name |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[candidates.json.gz v0.7] -->|routeFromCandidate| B[PythonRoute]
    B -->|normalizeRouteForRetrocast| C[RetrocastRoute]
    C -->|projectRetrocastRoute| D[signature / length / isConvergent]
    D --> E[(Route DB)]
    E --> F[(RouteNode tree)]
    G[evaluation.json.gz v0.7] -->|candidateIsSolved| H[isSolvable bool]
    H --> I[(RouteSolvability DB)]
    J[analysis.json.gz v0.7] -->|transformRetrocastAnalysis| K[ModelStatistics]
    K --> L[(ModelRunStatistics DB)]
    M[benchmark definitions v0.7] -->|loadBenchmarkFromFile| N[BenchmarkTarget routeLength isConvergent]
    N -->|read back at eval time| I
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/lib/services/loaders/benchmark-loader.service.ts`, line 550-581 ([link](https://github.com/ischemist/syntharena/blob/4edcdfa7d73d6497b07d982bce70a03d87a9a90e/src/lib/services/loaders/benchmark-loader.service.ts#L550-L581)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Normalization helpers are duplicated verbatim across both service files**

   `getSynthesisStep`, `getAnnotations`, `normalizeMoleculeForRetrocast`, `normalizeReactionForRetrocast`, and `normalizeRouteForRetrocast` appear identically in both service files. If one copy evolves without updating the other, the two loaders will silently produce different database representations for the same route tree. Extracting these into a shared module would eliminate the drift risk.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/lib/services/loaders/benchmark-loader.service.ts
   Line: 550-581

   Comment:
   **Normalization helpers are duplicated verbatim across both service files**

   `getSynthesisStep`, `getAnnotations`, `normalizeMoleculeForRetrocast`, `normalizeReactionForRetrocast`, and `normalizeRouteForRetrocast` appear identically in both service files. If one copy evolves without updating the other, the two loaders will silently produce different database representations for the same route tree. Extracting these into a shared module would eliminate the drift risk.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix: address retrocast loader review com..."](https://github.com/ischemist/syntharena/commit/16b2528be0f6713df61d7ad4cb0cf3f8b25dfd36) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37351309)</sub>

<!-- /greptile_comment -->