### PR TITLE
feat: show stock metadata in route previews

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from 'next'
 import packageJson from './package.json'
 
 const nextConfig: NextConfig = {
+    allowedDevOrigins: ['100.120.112.3'],
     env: {
         NEXT_PUBLIC_APP_VERSION: packageJson.version,
     },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "format:check": "oxfmt --check"
     },
     "dependencies": {
-        "@ischemist/route-viewer": "0.1.0",
+        "@ischemist/route-viewer": "0.1.1",
         "@ischemist/routes": "0.1.0",
         "@prisma/adapter-better-sqlite3": "^7.0.0",
         "@prisma/client": "^7.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@ischemist/route-viewer':
-        specifier: 0.1.0
-        version: 0.1.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: 0.1.1
+        version: 0.1.1(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@ischemist/routes':
         specifier: 0.1.0
         version: 0.1.0
@@ -782,8 +782,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@ischemist/route-viewer@0.1.0':
-    resolution: {integrity: sha512-qvBZSl70/INZFvqLPFFocXuTa/mckVs/qa0NZaefcvdnSub9mHV+IiiKLxmyhuLtSKar8/BJVWWKS8hUzn/idg==}
+  '@ischemist/route-viewer@0.1.1':
+    resolution: {integrity: sha512-Il/CVV6s70/8VFqEDJXMGstNMOHwamPQo7LmBuRd0yK1zsiOIe3q/h4MIHh09+6pWfk4whEqT7LBJu2vDeXtiQ==}
     peerDependencies:
       react: '>=19'
       react-dom: '>=19'
@@ -3688,7 +3688,7 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@ischemist/route-viewer@0.1.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@ischemist/route-viewer@0.1.1(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@ischemist/routes': 0.1.0
       '@xyflow/react': 12.11.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)

--- a/scripts/load-predictions.ts
+++ b/scripts/load-predictions.ts
@@ -63,6 +63,7 @@ import './env-loader'
 
 import prisma from '../src/lib/db'
 import {
+    computeRouteLength,
     createModelStatistics,
     createOrUpdatePredictionRun,
     createRouteFromPython,
@@ -252,6 +253,7 @@ function fileExists(filePath: string): boolean {
 
 function routeFromCandidate(candidate: CandidatesFile[string][number]): PythonRoute | null {
     if (!candidate.route) return null
+    if (computeRouteLength(candidate.route.target) === 0) return null
     return {
         ...candidate.route,
         rank: candidate.rank,

--- a/scripts/load-predictions.ts
+++ b/scripts/load-predictions.ts
@@ -252,7 +252,7 @@ function fileExists(filePath: string): boolean {
 }
 
 function routeFromCandidate(candidate: CandidatesFile[string][number]): PythonRoute | null {
-    if (!candidate.route) return null
+    if (!candidate.route?.target) return null
     if (computeRouteLength(candidate.route.target) === 0) return null
     return {
         ...candidate.route,

--- a/src/components/route-visualization/route-graph.tsx
+++ b/src/components/route-visualization/route-graph.tsx
@@ -12,7 +12,7 @@ interface RouteGraphProps {
     inStockInchiKeys: Set<string>
     buyableMetadataMap?: Map<string, BuyableMetadata>
     idPrefix?: string
-    preCalculatedNodes?: Array<{ id: string; smiles: string; inchikey: string; x: number; y: number }>
+    preCalculatedNodes?: Array<{ id: string; smiles: string; inchikey: string; x: number; y: number; isLeaf?: boolean }>
     preCalculatedEdges?: Array<{ source: string; target: string }>
 }
 
@@ -26,10 +26,13 @@ export function RouteGraph({
 }: RouteGraphProps) {
     const { nodes, edges } = useMemo(() => {
         if (preCalculatedNodes && preCalculatedEdges) {
+            const parentNodeIds = new Set(preCalculatedEdges.map((edge) => edge.source))
+
             return {
                 nodes: preCalculatedNodes.map((node) => {
                     const inStock = inStockInchiKeys.has(node.inchikey)
                     const metadata = buyableMetadataMap?.get(node.inchikey)
+                    const isLeaf = node.isLeaf ?? !parentNodeIds.has(node.id)
 
                     return {
                         id: node.id,
@@ -40,6 +43,7 @@ export function RouteGraph({
                             inchikey: node.inchikey,
                             status: 'default',
                             inStock,
+                            isLeaf,
                             ppg: metadata?.ppg,
                             source: metadata?.source,
                             leadTime: metadata?.leadTime,

--- a/src/lib/services/data/route.data.ts
+++ b/src/lib/services/data/route.data.ts
@@ -92,7 +92,11 @@ export const findFirstAcceptableMatchRank = cache(_findFirstAcceptableMatchRank,
 /** fetches a lightweight list of prediction summaries (rank, routeId) for a target in a run. */
 async function _findPredictionSummaries(targetId: string, runId: string) {
     return prisma.predictionRoute.findMany({
-        where: { targetId, predictionRunId: runId },
+        where: {
+            targetId,
+            predictionRunId: runId,
+            route: { length: { gt: 0 } },
+        },
         select: {
             rank: true,
             routeId: true,
@@ -106,13 +110,12 @@ export const findPredictionSummaries = cache(_findPredictionSummaries, ['predict
 
 /** fetches a single predicted route by rank, with its solvability status. */
 async function _findSinglePredictionForTarget(targetId: string, runId: string, rank: number, stockId?: string) {
-    return prisma.predictionRoute.findUnique({
+    return prisma.predictionRoute.findFirst({
         where: {
-            predictionRunId_targetId_rank: {
-                predictionRunId: runId,
-                targetId: targetId,
-                rank: rank,
-            },
+            predictionRunId: runId,
+            targetId: targetId,
+            rank: rank,
+            route: { length: { gt: 0 } },
         },
         include: {
             route: true, // we need the route metadata

--- a/src/lib/services/view/prediction.view.ts
+++ b/src/lib/services/view/prediction.view.ts
@@ -601,7 +601,7 @@ export async function getTargetDisplayData(
 
     const solvabilityRecord = prediction?.solvabilityStatus.find((s) => s.stockId === stockId)
     let currentPrediction: TargetDisplayData['currentPrediction'] = null
-    if (prediction && predictedVizNode && (prediction.route.length > 0 || solvabilityRecord?.isSolvable === true)) {
+    if (prediction && predictedVizNode) {
         currentPrediction = {
             predictionRoute: prediction,
             route: prediction.route,

--- a/src/lib/services/view/prediction.view.ts
+++ b/src/lib/services/view/prediction.view.ts
@@ -599,10 +599,12 @@ export async function getTargetDisplayData(
         { availableRanks: predictionSummaries.map((s) => s.rank), totalAcceptableRoutes }
     )
 
+    const solvabilityRecord = prediction?.solvabilityStatus.find((s) => s.stockId === stockId)
+    const shouldDisplayPrediction =
+        prediction && predictedVizNode && (prediction.route.length > 0 || solvabilityRecord?.isSolvable === true)
     const currentPrediction =
-        prediction && predictedVizNode
+        shouldDisplayPrediction && prediction && predictedVizNode
             ? (() => {
-                  const solvabilityRecord = prediction.solvabilityStatus.find((s) => s.stockId === stockId)
                   return {
                       predictionRoute: prediction,
                       route: prediction.route,

--- a/src/lib/services/view/prediction.view.ts
+++ b/src/lib/services/view/prediction.view.ts
@@ -600,27 +600,23 @@ export async function getTargetDisplayData(
     )
 
     const solvabilityRecord = prediction?.solvabilityStatus.find((s) => s.stockId === stockId)
-    const shouldDisplayPrediction =
-        prediction && predictedVizNode && (prediction.route.length > 0 || solvabilityRecord?.isSolvable === true)
-    const currentPrediction =
-        shouldDisplayPrediction && prediction && predictedVizNode
-            ? (() => {
-                  return {
-                      predictionRoute: prediction,
-                      route: prediction.route,
-                      visualizationNode: predictedVizNode,
-                      // FIX: correctly map the record to the DTO shape
-                      solvability: solvabilityRecord
-                          ? {
-                                stockId: solvabilityRecord.stockId,
-                                stockName: solvabilityRecord.stock.name,
-                                isSolvable: solvabilityRecord.isSolvable,
-                                matchesAcceptable: solvabilityRecord.matchesAcceptable,
-                            }
-                          : undefined,
+    let currentPrediction: TargetDisplayData['currentPrediction'] = null
+    if (prediction && predictedVizNode && (prediction.route.length > 0 || solvabilityRecord?.isSolvable === true)) {
+        currentPrediction = {
+            predictionRoute: prediction,
+            route: prediction.route,
+            visualizationNode: predictedVizNode,
+            // FIX: correctly map the record to the DTO shape
+            solvability: solvabilityRecord
+                ? {
+                      stockId: solvabilityRecord.stockId,
+                      stockName: solvabilityRecord.stock.name,
+                      isSolvable: solvabilityRecord.isSolvable,
+                      matchesAcceptable: solvabilityRecord.matchesAcceptable,
                   }
-              })()
-            : null
+                : undefined,
+        }
+    }
 
     return {
         targetInfo: { ...targetInfo, hasNoPredictions: !hasPredictions },


### PR DESCRIPTION
## why
route previews can now show stock vendor and price metadata through the published route-viewer package, but syntharena needs to pass the right leaf metadata shape into that package. without this, in-stock leaves keep rendering as generic stock states and precomputed layouts do not reliably identify which nodes are leaves.

this also fixes a bad preview edge case found while testing the feature: some imported predictions stored target-only routes as real predictions, making unsolved runs render a single root node with `length: 0` instead of no prediction route.

## what changed
syntharena now depends on published `@ischemist/route-viewer@0.1.1`, which contains the vendor/price badge rendering. precomputed route graph nodes recover `isLeaf` from the edge set before passing node data into route-viewer so leaf-only stock badges render in prediction previews.

zero-step prediction routes are now handled at the right boundaries: the import script drops missing-target and zero-length candidate routes before persistence, and the route data layer only returns prediction summaries/single predictions whose joined route has `length > 0`. the view layer now just renders a prediction when the data layer returns one, instead of carrying its own zero-step solvability exception.

`next.config.ts` now allows the remote dev origin used for local preview access.

## risk
moderate-low. request-time behavior is read-only; the importer change only affects future prediction loads, while the data-layer filter changes how already-imported zero-step prediction rows participate in route preview navigation/rendering. the important boundary is that stock-solvable target-only state should come from stock/solvability data, not from pretending there is a prediction route.

the dev-origin config only affects allowed development origins.

## verification
- `pnpm check-types`
- `pnpm lint`
- `pnpm test:run`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires stock vendor/price metadata into route previews by bumping `@ischemist/route-viewer` to 0.1.1 and propagating `isLeaf` and `BuyableMetadata` fields through `RouteGraph`. It also closes a bad-data edge case where target-only (length-0) candidates were stored as real prediction routes.

- **`route-graph.tsx`**: derives `isLeaf` from the edge set (`!parentNodeIds.has(node.id)`) when not pre-supplied, so leaf stock badges render correctly in prediction previews.
- **`route.data.ts`**: adds a `route: { length: { gt: 0 } }` filter to both `findPredictionSummaries` and `findSinglePredictionForTarget`; the latter had to switch from `findUnique` to `findFirst` to allow the nested relation filter.
- **`load-predictions.ts`**: drops candidates at import time when `route.target` is absent or `computeRouteLength` returns 0, preventing future bad records from entering the DB.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are read-only at request time, the import fix only affects future loads, and the zero-length route filtering is applied consistently at both the data and import layers.

The data-layer filtering is consistent across findPredictionSummaries and findSinglePredictionForTarget, the isLeaf derivation from edges is logically correct, and the import guard properly pairs the target null-check with the length check. The findUnique to findFirst switch is forced by Prisma API constraints and does not introduce incorrect behavior under normal DB integrity.

src/lib/services/data/route.data.ts — the findFirst substitution is correct but loses the compile-time unique-index guarantee; worth a comment at the call site.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| next.config.ts | Adds allowedDevOrigins with a single Tailscale IP for local preview access; no production impact. |
| package.json | Bumps @ischemist/route-viewer from 0.1.0 to 0.1.1 to pull in vendor/price badge rendering. |
| scripts/load-predictions.ts | Adds candidate.route?.target guard and computeRouteLength === 0 check to drop target-only routes at import time. |
| src/components/route-visualization/route-graph.tsx | Derives isLeaf from edges when not already set on pre-calculated nodes, enabling stock badge rendering on prediction previews. |
| src/lib/services/data/route.data.ts | Switches findSinglePredictionForTarget from findUnique to findFirst with a route.length > 0 filter; also adds the same filter to findPredictionSummaries. |
| src/lib/services/view/prediction.view.ts | Refactors currentPrediction assembly from an IIFE into an explicit let/if block; solvabilityRecord is now computed outside the guard (safe via optional chaining). |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Import: load-predictions.ts] -->|candidate.route?.target exists AND computeRouteLength > 0| B[createRouteFromPython]
    A -->|route missing or length = 0| C[Drop candidate]
    D[Query: findPredictionSummaries] -->|route.length > 0 filter| E[Rank list for navigation]
    F[Query: findSinglePredictionForTarget findFirst + route.length > 0] -->|found| G[prediction object]
    F -->|null| H[currentPrediction = null]
    G --> I{prediction and predictedVizNode?}
    I -->|yes| J[Build currentPrediction DTO with solvabilityRecord]
    I -->|no| K[currentPrediction = null]
    L[RouteGraph preCalculatedNodes] --> M{node.isLeaf set?}
    M -->|yes| N[use node.isLeaf]
    M -->|no| O[isLeaf = !parentNodeIds.has node.id]
    N --> P[pass isLeaf + stock metadata to route-viewer]
    O --> P
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Import: load-predictions.ts] -->|candidate.route?.target exists AND computeRouteLength > 0| B[createRouteFromPython]
    A -->|route missing or length = 0| C[Drop candidate]
    D[Query: findPredictionSummaries] -->|route.length > 0 filter| E[Rank list for navigation]
    F[Query: findSinglePredictionForTarget findFirst + route.length > 0] -->|found| G[prediction object]
    F -->|null| H[currentPrediction = null]
    G --> I{prediction and predictedVizNode?}
    I -->|yes| J[Build currentPrediction DTO with solvabilityRecord]
    I -->|no| K[currentPrediction = null]
    L[RouteGraph preCalculatedNodes] --> M{node.isLeaf set?}
    M -->|yes| N[use node.isLeaf]
    M -->|no| O[isLeaf = !parentNodeIds.has node.id]
    N --> P[pass isLeaf + stock metadata to route-viewer]
    O --> P
```

</a>

<sub>Reviews (5): Last reviewed commit: ["refactor: filter displayable prediction ..."](https://github.com/ischemist/syntharena/commit/8ff1930c14c4a39004aca554e053b6218f5fef5a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37648041)</sub>

<!-- /greptile_comment -->