### PR TITLE
chore: release 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "syntharena",
-    "version": "0.4.1",
+    "version": "0.5.0",
     "private": true,
     "scripts": {
         "dev": "next dev",

--- a/src/app/(info)/changelog/page.tsx
+++ b/src/app/(info)/changelog/page.tsx
@@ -9,6 +9,32 @@ export const metadata: Metadata = {
 
 const versions = [
     {
+        version: 'v0.5.0',
+        date: 'August 4, 2026',
+        changes: [
+            {
+                type: ChangeType.FEAT,
+                description:
+                    'Reframed target-level results in the Solv-N framework: fraction Tier-0 valid and Solv-0[stock], without implying unmeasured Tier-1 validity',
+            },
+            {
+                type: ChangeType.DATA,
+                description:
+                    'Rebuilt the benchmark corpus from RetroCast v0.8.3 schema-v2 outputs, replacing the legacy v0.5 representation and restoring verified runtime and cost data for all 84 runs',
+            },
+            {
+                type: ChangeType.UI_UX,
+                description:
+                    'Added readable canonical benchmark slugs with permanent redirects for legacy benchmark, run, and target URLs',
+            },
+            {
+                type: ChangeType.PERF,
+                description:
+                    'Introduced a reproducible streaming Rust corpus builder with artifact provenance checks and optimized SQLite loading',
+            },
+        ],
+    },
+    {
         version: 'v0.4.1',
         date: 'May 5, 2026',
         changes: [


### PR DESCRIPTION
## why

PR #87 introduced the Solv-N data model and production corpus, but the application still identified itself as v0.4.1 and had no user-facing record of the migration. The deployed release needs to state exactly what is measured so Tier-0/Solv-0 results are not mistaken for Tier-1 evidence.

## what changed

- Bump the application version to v0.5.0.
- Add an in-app changelog entry for Tier-0 validity, Solv-0[stock], the RetroCast v0.8.3 schema-v2 corpus rebuild, restored runtime/cost data, canonical URL redirects, and the streaming Rust builder.
- Explicitly state that the release does not imply unmeasured Tier-1 validity.

## risk

Low: this changes release metadata and static changelog content only. It does not alter the database, routing, or ingestion behavior. The claims were checked against the production candidate and merged implementation.

## verification

- `pnpm check-types`
- `pnpm lint`
- `pnpm test:run` (195 tests)
- Prettier and `git diff --check`
- Independent adversarial review against the candidate database and redirect implementation

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ischemist/codesmith/syntharena/pr/88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788502639&installation_model_id=19379&pr_number=88&repository=ischemist%2Fsyntharena&return_to=https%3A%2F%2Fgithub.com%2Fischemist%2Fsyntharena%2Fpull%2F88&signature=f76335f14d10a334f4a2e090a9d1c6d5afb3ca98727ea9759680472a536d286f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a changelog entry for version 0.5.0.
  - Documented improved Solv-N result framing.
  - Documented the rebuilt benchmark corpus and canonical benchmark links with redirects.
  - Documented a reproducible streaming Rust corpus builder.
- **Chores**
  - Updated the application version to 0.5.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prepares the v0.5.0 release by synchronizing application metadata and adding user-facing release notes that clarify the scope of Solv-N results.
- Updates the package version from 0.4.1 to 0.5.0.
- Documents the Solv-N framing, rebuilt corpus, canonical URL redirects, and streaming Rust corpus builder.
- Explicitly distinguishes measured Tier-0 validity from unmeasured Tier-1 validity.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the release metadata and static changelog content consistent with existing application contracts.

The root version propagates through the existing package-derived version source, while the changelog entry uses valid mapped change types and follows established rendering, ordering, and date conventions.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| package.json | Updates the root application version to 0.5.0; existing version consumers derive their displayed value from this manifest, and no lockfile synchronization is required. |
| src/app/(info)/changelog/page.tsx | Adds a correctly shaped, newest-first v0.5.0 changelog entry using fully supported change categories. |

<sub>Reviews (1): Last reviewed commit: ["chore: release 0.5.0"](https://github.com/ischemist/syntharena/commit/b94fc97250f3fd474ddc7da80d011fa9e39aa0ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50339500)</sub>

<!-- /greptile_comment -->