### PR TITLE
chore: add deployment image export

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -4,6 +4,12 @@ on:
     push:
         branches: [master]
     workflow_dispatch:
+        inputs:
+            export_artifact:
+                description: Export the exact app image as a deployment artifact
+                required: false
+                default: false
+                type: boolean
 
 permissions:
     contents: read
@@ -55,6 +61,7 @@ jobs:
                   max-cache-size-mb: '10240'
 
             - name: Build app image
+              id: app-build
               uses: useblacksmith/build-push-action@v2
               with:
                   context: .
@@ -77,3 +84,30 @@ jobs:
                       org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
                       org.opencontainers.image.revision=${{ github.sha }}
                       org.opencontainers.image.created=${{ steps.image.outputs.created }}
+
+            - name: Export exact app image
+              if: ${{ github.event_name == 'workflow_dispatch' && inputs.export_artifact }}
+              env:
+                  DIGEST: ${{ steps.app-build.outputs.digest }}
+                  IMAGE: ${{ steps.image.outputs.image }}
+              run: |
+                  REF="${IMAGE}@${DIGEST}"
+                  TAG="${IMAGE}:sha-${GITHUB_SHA}"
+                  ARCHIVE="syntharena-${GITHUB_SHA}.tar"
+                  docker pull "${REF}"
+                  docker tag "${REF}" "${TAG}"
+                  docker save --output "${ARCHIVE}" "${TAG}"
+                  sha256sum "${ARCHIVE}" > "${ARCHIVE}.sha256"
+                  printf '%s\n' "${REF}" > "${ARCHIVE}.image-digest"
+
+            - name: Upload exact app image
+              if: ${{ github.event_name == 'workflow_dispatch' && inputs.export_artifact }}
+              uses: actions/upload-artifact@v4
+              with:
+                  name: syntharena-deployment-image-${{ github.sha }}
+                  path: |
+                      syntharena-${{ github.sha }}.tar
+                      syntharena-${{ github.sha }}.tar.sha256
+                      syntharena-${{ github.sha }}.tar.image-digest
+                  compression-level: 0
+                  retention-days: 1


### PR DESCRIPTION
## why

Production deploys consume the private GHCR image, but a stale or insufficient host credential can make the exact image unavailable at cutover time. Falling back to `latest`, changing package visibility, or rebuilding under emulation weakens revision guarantees. Operators need a short-lived, checksummed way to retrieve the exact CI-built app image through repository-scoped Actions access.

## what changed

- Add an opt-in `export_artifact` input to manual Docker workflow runs.
- Pull the app image by the immutable digest emitted by the build step and save that exact image as a tar archive.
- Upload archive checksum and registry-digest sidecars with one-day retention.
- Leave normal push builds unchanged and omit the migration image from the export.

## risk

The export is disabled by default and only runs on an explicit manual dispatch. Manual dispatch on `master` retains the workflow's existing behavior of also updating `latest`; deployment still validates the exported image's embedded revision before use. The artifact contains the public application image and expires after one day.

## verification

- Prettier
- `git diff --check`
- `actionlint` (only the pre-existing custom Blacksmith runner-label warning)
- Independent adversarial review, including an exact-digest correction after mutable-tag analysis

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ischemist/codesmith/syntharena/pr/89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788503813&installation_model_id=19379&pr_number=89&repository=ischemist%2Fsyntharena&return_to=https%3A%2F%2Fgithub.com%2Fischemist%2Fsyntharena%2Fpull%2F89&signature=3d3617d3e0c6cdb6a9e5cc072fc2f57ff9bd0dacc08f71f76835c52be68ac347"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds an opt-in manual workflow path that exports the exact digest produced by the app-image build as a short-lived deployment artifact.
- Adds the `export_artifact` workflow-dispatch input.
- Pulls and saves the app image using the build output’s immutable registry digest.
- Uploads the image archive, SHA-256 checksum, and digest reference with one-day retention.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issue identified.

The manual-only path uses the app build’s digest with the matching GHCR repository, saves that pulled image, and uploads the expected archive and integrity sidecars while leaving normal runs gated out.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/docker-image.yml | Adds a manual-only, digest-addressed app-image export and artifact upload path without changing ordinary push-run behavior. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Manual workflow dispatch] --> B{export_artifact enabled?}
    B -- No --> C[Build and push images normally]
    B -- Yes --> D[Build and push app image]
    D --> E[Read app-build digest]
    E --> F[Pull IMAGE at immutable digest]
    F --> G[Tag and save image archive]
    G --> H[Generate checksum and digest sidecars]
    H --> I[Upload artifact with one-day retention]
```

<sub>Reviews (1): Last reviewed commit: ["chore: add deployment image export"](https://github.com/ischemist/syntharena/commit/00e516769ef0eac7df2635d3fa50e7346da90cc6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50343110)</sub>

<!-- /greptile_comment -->