### PR TITLE
fix: resolve production image digest reliably

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -102,6 +102,13 @@ jobs:
         runs-on: blacksmith-2vcpu-ubuntu-2404
 
         steps:
+            - name: Checkout deployment tooling from workflow revision
+              uses: actions/checkout@v4
+              with:
+                  # Rollback targets can predate this helper; execute tooling from the exact workflow revision.
+                  ref: ${{ github.workflow_sha }}
+                  persist-credentials: false
+
             - name: Login to GHCR to resolve immutable image
               uses: docker/login-action@v4
               with:
@@ -115,7 +122,7 @@ jobs:
                   DEPLOY_SHA: ${{ needs.prepare.outputs.sha }}
               run: |
                   image="ghcr.io/${GITHUB_REPOSITORY,,}:sha-${DEPLOY_SHA}"
-                  digest="$(docker buildx imagetools inspect "$image" --format '{{.Manifest.Digest}}')"
+                  digest="$(./scripts/resolve-image-digest.sh "$image")"
                   if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
                     echo "registry returned an invalid image digest: $digest" >&2
                     exit 1

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -29,7 +29,7 @@ jobs:
 
         steps:
             - name: Checkout requested revision
-              uses: actions/checkout@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
               with:
                   fetch-depth: 0
                   ref: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.sha }}
@@ -103,7 +103,7 @@ jobs:
 
         steps:
             - name: Checkout deployment tooling from workflow revision
-              uses: actions/checkout@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
               with:
                   # Rollback targets can predate this helper; execute tooling from the exact workflow revision.
                   ref: ${{ github.workflow_sha }}

--- a/scripts/resolve-image-digest.sh
+++ b/scripts/resolve-image-digest.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+image="${1:-}"
+if [[ ! "$image" =~ ^ghcr\.io/ischemist/syntharena:sha-[0-9a-f]{40}$ ]]; then
+    echo "usage: resolve-image-digest.sh ghcr.io/ischemist/syntharena:sha-<full-sha>" >&2
+    exit 64
+fi
+
+raw_manifest="$(mktemp)"
+cleanup() {
+    rm -f "$raw_manifest"
+}
+trap cleanup EXIT
+
+# An OCI/Docker manifest digest is the SHA-256 of its exact registry bytes.
+# Hash --raw output instead of parsing version-dependent human/Go-template
+# output from buildx; for a multi-platform image this is the top-level index.
+docker buildx imagetools inspect "$image" --raw >"$raw_manifest"
+if [ ! -s "$raw_manifest" ]; then
+    echo "registry returned an empty top-level image manifest" >&2
+    exit 1
+fi
+
+manifest_sha="$(sha256sum "$raw_manifest" | awk '{print $1}')"
+if [[ ! "$manifest_sha" =~ ^[0-9a-f]{64}$ ]]; then
+    echo "could not hash the top-level image manifest" >&2
+    exit 1
+fi
+
+printf 'sha256:%s\n' "$manifest_sha"

--- a/tests/scripts/resolve-image-digest.test.ts
+++ b/tests/scripts/resolve-image-digest.test.ts
@@ -10,6 +10,7 @@ const repoRoot = resolve(import.meta.dirname, '../..')
 const resolver = join(repoRoot, 'scripts/resolve-image-digest.sh')
 const revision = '1'.repeat(40)
 const image = `ghcr.io/ischemist/syntharena:sha-${revision}`
+const pinnedCheckout = 'uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2'
 
 function runResolver(rawManifest: string) {
     const fixture = mkdtempSync(join(tmpdir(), 'syntharena-image-digest-'))
@@ -52,10 +53,14 @@ describe('image digest resolver', () => {
 
         expect(checkout).toBeGreaterThan(-1)
         expect(resolverCall).toBeGreaterThan(checkout)
+        expect(checkoutBlock).toContain(pinnedCheckout)
         expect(checkoutBlock).toContain('ref: ${{ github.workflow_sha }}')
         expect(checkoutBlock).not.toContain('ref: ${{ needs.prepare.outputs.sha }}')
         expect(checkoutBlock).toContain('Rollback targets can predate this helper')
         expect(checkoutBlock).toContain('persist-credentials: false')
+
+        const checkoutUses = workflow.match(/uses: actions\/checkout@\S+(?:\s+#.*)?/g) ?? []
+        expect(checkoutUses).toEqual([pinnedCheckout, pinnedCheckout])
     })
 
     test('hashes the exact raw top-level OCI index bytes', () => {

--- a/tests/scripts/resolve-image-digest.test.ts
+++ b/tests/scripts/resolve-image-digest.test.ts
@@ -1,0 +1,76 @@
+import { spawnSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+import { describe, expect, test } from 'vitest'
+
+const repoRoot = resolve(import.meta.dirname, '../..')
+const resolver = join(repoRoot, 'scripts/resolve-image-digest.sh')
+const revision = '1'.repeat(40)
+const image = `ghcr.io/ischemist/syntharena:sha-${revision}`
+
+function runResolver(rawManifest: string) {
+    const fixture = mkdtempSync(join(tmpdir(), 'syntharena-image-digest-'))
+    const bin = join(fixture, 'bin')
+    mkdirSync(bin)
+    const docker = join(bin, 'docker')
+    writeFileSync(
+        docker,
+        `#!/usr/bin/env bash
+if [ "$*" != "buildx imagetools inspect ${image} --raw" ]; then
+    printf 'unexpected docker command: %s\n' "$*" >&2
+    exit 1
+fi
+printf '%s' "$RAW_MANIFEST"
+`
+    )
+    chmodSync(docker, 0o755)
+
+    try {
+        return spawnSync('bash', [resolver, image], {
+            cwd: repoRoot,
+            encoding: 'utf8',
+            env: {
+                ...process.env,
+                PATH: `${bin}:${process.env.PATH}`,
+                RAW_MANIFEST: rawManifest,
+            },
+        })
+    } finally {
+        rmSync(fixture, { force: true, recursive: true })
+    }
+}
+
+describe('image digest resolver', () => {
+    test('checks out resolver tooling from the running workflow revision so older rollback targets remain deployable', () => {
+        const workflow = readFileSync(join(repoRoot, '.github/workflows/deploy-production.yml'), 'utf8')
+        const checkout = workflow.indexOf('- name: Checkout deployment tooling from workflow revision')
+        const resolverCall = workflow.indexOf('digest="$(./scripts/resolve-image-digest.sh "$image")"')
+        const checkoutBlock = workflow.slice(checkout, resolverCall)
+
+        expect(checkout).toBeGreaterThan(-1)
+        expect(resolverCall).toBeGreaterThan(checkout)
+        expect(checkoutBlock).toContain('ref: ${{ github.workflow_sha }}')
+        expect(checkoutBlock).not.toContain('ref: ${{ needs.prepare.outputs.sha }}')
+        expect(checkoutBlock).toContain('Rollback targets can predate this helper')
+        expect(checkoutBlock).toContain('persist-credentials: false')
+    })
+
+    test('hashes the exact raw top-level OCI index bytes', () => {
+        const manifest = '{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[]}'
+        const expected = createHash('sha256').update(manifest).digest('hex')
+        const result = runResolver(manifest)
+
+        expect(result.status, result.stderr).toBe(0)
+        expect(result.stdout).toBe(`sha256:${expected}\n`)
+    })
+
+    test('rejects empty registry output instead of accepting the empty-content hash', () => {
+        const result = runResolver('')
+
+        expect(result.status).not.toBe(0)
+        expect(result.stderr).toContain('empty top-level image manifest')
+    })
+})


### PR DESCRIPTION
## why
The first production workflow dispatch stopped before SSH because Buildx on the Blacksmith runner rendered a multi-line image-index report for `--format '{{.Manifest.Digest}}'`. The digest existed, but strict validation correctly rejected the non-scalar output. The release path needs a runner-independent way to freeze the exact top-level OCI digest without weakening immutable deployment or breaking compatible rollback targets.

## what changed
The workflow now hashes the exact raw top-level manifest/index bytes returned by the registry and retains an independent strict `sha256:<64hex>` check. Deployment tooling is checked out from `github.workflow_sha`, the exact commit containing the running workflow, while the image and host deployment remain independently pinned to the already validated requested SHA. This keeps prior contract-compatible rollback revisions usable even when they predate the helper.

## risk
This changes only the pre-SSH digest-resolution boundary. Empty registry output, malformed identities, and command failures remain fail-closed. Checkout has read-only contents permission and does not persist credentials. No VM, database, Nginx, or application state was changed by the failed dispatch or this patch.

## verification
- Focused resolver and workflow regression tests: 3/3
- Full suite: 226/226 in adversarial review
- ShellCheck and Bash syntax
- Actionlint (excluding existing Blacksmith custom-label diagnostics)
- `pnpm check-types`
- `pnpm lint`
- `pnpm format:check`
- `git diff --check`
- Raw-byte digest matched Buildx's reported top-level digest on public multi-platform images
- Independent adversarial review approved the final revision boundary

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ischemist/codesmith/syntharena/pr/91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788554828&installation_model_id=19379&pr_number=91&repository=ischemist%2Fsyntharena&return_to=https%3A%2F%2Fgithub.com%2Fischemist%2Fsyntharena%2Fpull%2F91&signature=4f458d2fc2c136b302fe8b0d2c370db0b6b25e8659cf8438ce704004d24dceab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production deployment reliability when resolving container image versions.
  * Added validation to prevent deployments from proceeding with missing or invalid image digests.

* **Tests**
  * Added automated coverage for image verification, deployment revision handling, and empty registry responses.

* **Chores**
  * Updated deployment tooling checkout behavior to ensure deployments use the intended workflow revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes production image resolution runner-independent while preserving immutable deployment boundaries.
- Hashes the registry’s raw top-level manifest bytes and validates the resulting digest.
- Checks out deployment tooling from the exact workflow revision.
- Pins both `actions/checkout` uses to a full commit SHA.
- Adds regression coverage for checkout configuration, digest generation, and empty registry responses.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported mutable checkout reference is now pinned to a full commit SHA in both checkout steps.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/deploy-production.yml | Uses workflow-revision tooling, invokes the new resolver, and replaces mutable checkout references with a full commit pin. |
| scripts/resolve-image-digest.sh | Validates the image identity, hashes exact raw registry bytes, and fails closed on empty or malformed output. |
| tests/scripts/resolve-image-digest.test.ts | Covers immutable checkout configuration, exact raw-byte hashing, and rejection of empty registry output. |

<sub>Reviews (2): Last reviewed commit: ["fix: pin production checkout action"](https://github.com/ischemist/syntharena/commit/82aa9d814788c0603633341f4cb679db6767cac6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50592695)</sub>

<!-- /greptile_comment -->